### PR TITLE
Fix live tv dropdown filters for country and genre

### DIFF
--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/fragments/TvFragment.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/fragments/TvFragment.java
@@ -99,10 +99,10 @@ public class TvFragment extends Fragment {
                 loaded=true;
                 page = 0;
                 loading = true;
-                // Don't load data here - it will be loaded by HomeActivity
-                // getCountiesList();
-                // getCategoriesList();
-                // loadChannels();
+                // Load data when fragment becomes visible
+                getCountiesList();
+                getCategoriesList();
+                loadChannels();
             }
         }
     }
@@ -147,9 +147,11 @@ public class TvFragment extends Fragment {
                         spinner_fragement_channel_countries_list.setAdapter(filtresAdapter);
                         relative_layout_frament_channel_countries.setVisibility(View.VISIBLE);
                         
+                        Log.d("TvFragment", "Loaded " + countriesList.size() + " countries");
 
                     } else {
                         relative_layout_frament_channel_countries.setVisibility(View.GONE);
+                        Log.d("TvFragment", "No countries found in API response");
                     }
                 }
             }
@@ -158,6 +160,7 @@ public class TvFragment extends Fragment {
             public void onFailure(Call<my.cinemax.app.free.entity.JsonApiResponse> call, Throwable t) {
                 // Hide country filter if loading fails
                 relative_layout_frament_channel_countries.setVisibility(View.GONE);
+                Log.e("TvFragment", "Failed to load countries: " + t.getMessage());
             }
         });
     }
@@ -188,9 +191,11 @@ public class TvFragment extends Fragment {
                         spinner_fragement_channel_categories_list.setAdapter(filtresAdapter);
                         relative_layout_frament_channel_categories.setVisibility(View.VISIBLE);
                         
+                        Log.d("TvFragment", "Loaded " + categoryList.size() + " categories");
 
                     } else {
                         relative_layout_frament_channel_categories.setVisibility(View.GONE);
+                        Log.d("TvFragment", "No categories found in API response");
                     }
                 }
             }
@@ -199,6 +204,7 @@ public class TvFragment extends Fragment {
             public void onFailure(Call<my.cinemax.app.free.entity.JsonApiResponse> call, Throwable t) {
                 // Hide category filter if loading fails
                 relative_layout_frament_channel_categories.setVisibility(View.GONE);
+                Log.e("TvFragment", "Failed to load categories: " + t.getMessage());
             }
         });
     }
@@ -231,6 +237,7 @@ public class TvFragment extends Fragment {
                            countrySelected = 0;
                        }
                    }
+                   Log.d("TvFragment", "Country selected: " + countrySelected);
                    item = 0;
                    page = 0;
                    loading = true;
@@ -267,6 +274,7 @@ public class TvFragment extends Fragment {
                             categorySelected = 0;
                         }
                     }
+                    Log.d("TvFragment", "Category selected: " + categorySelected);
                     item = 0;
                     page = 0;
                     loading = true;
@@ -461,11 +469,20 @@ public class TvFragment extends Fragment {
                             if (countrySelected == 0) {
                                 // Show all countries
                                 matchesCountry = true;
+                            } else if (channel.getCountries() != null && !channel.getCountries().isEmpty()) {
+                                // Check if channel has the selected country
+                                for (Country country : channel.getCountries()) {
+                                    if (country.getId() != null && country.getId().intValue() == countrySelected) {
+                                        matchesCountry = true;
+                                        break;
+                                    }
+                                }
                             } else {
-                                // Simple country matching - check sublabel first
+                                // Fallback: use sublabel for country matching if countries list is empty
                                 String sublabel = channel.getSublabel();
                                 if (sublabel != null && !sublabel.isEmpty()) {
                                     String sublabelLower = sublabel.toLowerCase();
+                                    // Enhanced country matching based on sublabel
                                     if (countrySelected == 1 && (sublabelLower.contains("usa") || sublabelLower.contains("united states"))) {
                                         matchesCountry = true;
                                     } else if (countrySelected == 2 && (sublabelLower.contains("uk") || sublabelLower.contains("united kingdom"))) {
@@ -474,8 +491,8 @@ public class TvFragment extends Fragment {
                                         matchesCountry = true;
                                     } else if (countrySelected == 4 && sublabelLower.contains("germany")) {
                                         matchesCountry = true;
-                                    } else if (sublabelLower.contains("ph") || sublabelLower.contains("philippines")) {
-                                        // Show Philippines channels for any country selection
+                                    } else if (countrySelected == 5 && (sublabelLower.contains("ph") || sublabelLower.contains("philippines"))) {
+                                        // Handle Philippines channels
                                         matchesCountry = true;
                                     }
                                 }
@@ -486,7 +503,8 @@ public class TvFragment extends Fragment {
                             }
                         }
                         
-
+                        Log.d("TvFragment", "Total channels found: " + filteredChannels.size() + 
+                              " (Category: " + categorySelected + ", Country: " + countrySelected + ")");
                         
                         if (!filteredChannels.isEmpty()) {
                             // Only add channels if this is the first page or if we're loading more

--- a/CineMax/current_movie_api.json
+++ b/CineMax/current_movie_api.json
@@ -2001,6 +2001,14 @@
     {
       "id": 4,
       "title": "Documentary"
+    },
+    {
+      "id": 5,
+      "title": "Movies"
+    },
+    {
+      "id": 6,
+      "title": "General"
     }
   ],
   "countries": [
@@ -2019,6 +2027,10 @@
     {
       "id": 4,
       "title": "Germany"
+    },
+    {
+      "id": 5,
+      "title": "Philippines"
     }
   ],
   "subscription_plans": [],


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes Live TV dropdown filters for country and genre by correcting data loading, updating API data structure, and refining filtering logic.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation suffered from several issues: categories and countries were not properly loaded, the API's `current_movie_api.json` was missing "Movies", "General" categories and "Philippines" country, and the country filtering logic was flawed, leading to incorrect channel display when filters were applied. This PR addresses these mismatches and improves filtering accuracy.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3993e74-14c8-448f-9961-7b08ff9cdd0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3993e74-14c8-448f-9961-7b08ff9cdd0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>