### PR TITLE
Integrate TMDB metadata for movies and TV

### DIFF
--- a/CineMax/app/src/main/free_movie_api.json
+++ b/CineMax/app/src/main/free_movie_api.json
@@ -1,0 +1,77 @@
+[
+  {
+    "type": "movie",
+    "title": "Big Buck Bunny",
+    "sources": [
+      {
+        "type": "embed",
+        "url": "https://vidsrc.net/embed/movie/10346"
+      },
+      {
+        "type": "direct",
+        "url": "https://download.blender.org/peach/bbb.mp4"
+      }
+    ],
+    "meta": {
+      "tmdb_id": 10346,
+      "title": null,
+      "overview": null,
+      "release_date": null,
+      "poster_path": null,
+      "backdrop_path": null,
+      "genres": null,
+      "runtime": null,
+      "vote_average": null
+    }
+  },
+  {
+    "type": "tv",
+    "title": "Sample TV Series",
+    "meta": {
+      "tmdb_id": 1399,
+      "name": null,
+      "overview": null,
+      "first_air_date": null,
+      "poster_path": null,
+      "backdrop_path": null,
+      "genres": null,
+      "vote_average": null,
+      "seasons": [
+        {
+          "season_number": 1,
+          "episodes": [
+            {
+              "episode_number": 1,
+              "title": null,
+              "overview": null,
+              "air_date": null,
+              "sources": [
+                {
+                  "type": "embed",
+                  "url": "https://vidsrc.net/embed/tv/1399/1-1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "season_number": 2,
+          "episodes": [
+            {
+              "episode_number": 1,
+              "title": null,
+              "overview": null,
+              "air_date": null,
+              "sources": [
+                {
+                  "type": "embed",
+                  "url": "https://vidsrc.net/embed/tv/1399/2-1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/CineMax/app/src/main/java/my/cinemax/app/free/Utils/TmdbMetadataUtil.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/Utils/TmdbMetadataUtil.java
@@ -1,0 +1,62 @@
+package my.cinemax.app.free.Utils;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+public class TmdbMetadataUtil {
+    private static final String TMDB_MOVIE_URL = "https://api.themoviedb.org/3/movie/";
+    private static final String TMDB_TV_URL = "https://api.themoviedb.org/3/tv/";
+    private static final String TMDB_API_KEY_PARAM = "?api_key=";
+    private static final String TMDB_LANGUAGE_PARAM = "&language=en-US";
+
+    private static final OkHttpClient client = new OkHttpClient();
+
+    public static JSONObject fetchMovieMetadata(int tmdbId, String apiKey) throws IOException {
+        String url = TMDB_MOVIE_URL + tmdbId + TMDB_API_KEY_PARAM + apiKey + TMDB_LANGUAGE_PARAM;
+        Request request = new Request.Builder().url(url).build();
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                return new JSONObject(response.body().string());
+            }
+        }
+        return null;
+    }
+
+    public static JSONObject fetchTvMetadata(int tmdbId, String apiKey) throws IOException {
+        String url = TMDB_TV_URL + tmdbId + TMDB_API_KEY_PARAM + apiKey + TMDB_LANGUAGE_PARAM;
+        Request request = new Request.Builder().url(url).build();
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                return new JSONObject(response.body().string());
+            }
+        }
+        return null;
+    }
+
+    public static JSONObject fetchTvSeasonMetadata(int tmdbId, int seasonNumber, String apiKey) throws IOException {
+        String url = TMDB_TV_URL + tmdbId + "/season/" + seasonNumber + TMDB_API_KEY_PARAM + apiKey + TMDB_LANGUAGE_PARAM;
+        Request request = new Request.Builder().url(url).build();
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                return new JSONObject(response.body().string());
+            }
+        }
+        return null;
+    }
+
+    public static JSONObject fetchTvEpisodeMetadata(int tmdbId, int seasonNumber, int episodeNumber, String apiKey) throws IOException {
+        String url = TMDB_TV_URL + tmdbId + "/season/" + seasonNumber + "/episode/" + episodeNumber + TMDB_API_KEY_PARAM + apiKey + TMDB_LANGUAGE_PARAM;
+        Request request = new Request.Builder().url(url).build();
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                return new JSONObject(response.body().string());
+            }
+        }
+        return null;
+    }
+}

--- a/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
@@ -43,6 +43,8 @@ import org.json.JSONObject;
 
 import java.util.Properties;
 import java.io.FileInputStream;
+import my.cinemax.app.free.entity.Season;
+import my.cinemax.app.free.entity.Episode;
 
 /**
  * Created by Tamim on 28/09/2019.
@@ -352,24 +354,45 @@ public class apiClient {
                 } catch (Exception ignored) {}
             }
         }
-        // Enrich TV series (if you have a similar list for TV)
-        if (apiResponse.getCategories() != null) {
-            for (Object tvObj : apiResponse.getCategories()) {
+        // Enrich TV series (for Poster objects with type 'serie' or 'series')
+        if (apiResponse.getMovies() != null) {
+            for (Poster tv : apiResponse.getMovies()) {
                 try {
-                    // This assumes your TV series objects have a getMeta() method with tmdb_id, seasons, etc.
-                    // You may need to adjust this based on your actual data model.
-                    // Pseudocode for enrichment:
-                    // 1. Fetch series metadata
-                    // 2. For each season, fetch season metadata
-                    // 3. For each episode, fetch episode metadata
-                    // Example assumes a structure similar to the JSON you provided
-                    // (You may need to cast or adapt this for your actual model)
-                    // JSONObject meta = ...
-                    // int tmdbId = meta.getInt("tmdb_id");
-                    // JSONObject seriesMeta = TmdbMetadataUtil.fetchTvMetadata(tmdbId, tmdbApiKey);
-                    // ... fill series fields ...
-                    // JSONArray seasons = meta.getJSONArray("seasons");
-                    // for (int i = 0; i < seasons.length(); i++) { ... fetch season ... for each episode ... fetch episode ... }
+                    if (tv.getType() != null && (tv.getType().equalsIgnoreCase("serie") || tv.getType().equalsIgnoreCase("series") || tv.getType().equalsIgnoreCase("tv"))) {
+                        Integer tmdbId = null;
+                        try { tmdbId = Integer.valueOf(tv.getId()); } catch (Exception ignore) {}
+                        if (tmdbId != null) {
+                            JSONObject seriesMeta = TmdbMetadataUtil.fetchTvMetadata(tmdbId, tmdbApiKey);
+                            if (seriesMeta != null) {
+                                if (tv.getDescription() == null && seriesMeta.has("overview")) tv.setDescription(seriesMeta.getString("overview"));
+                                if (tv.getImage() == null && seriesMeta.has("poster_path")) tv.setImage("https://image.tmdb.org/t/p/w500" + seriesMeta.getString("poster_path"));
+                                if (tv.getCover() == null && seriesMeta.has("backdrop_path")) tv.setCover("https://image.tmdb.org/t/p/w780" + seriesMeta.getString("backdrop_path"));
+                                if (tv.getYear() == null && seriesMeta.has("first_air_date")) tv.setYear(seriesMeta.getString("first_air_date"));
+                                if (tv.getRating() == null && seriesMeta.has("vote_average")) tv.setRating((float) seriesMeta.getDouble("vote_average"));
+                            }
+                            // Enrich seasons
+                            if (tv.getSeasons() != null) {
+                                for (Season season : tv.getSeasons()) {
+                                    JSONObject seasonMeta = TmdbMetadataUtil.fetchTvSeasonMetadata(tmdbId, season.getId(), tmdbApiKey);
+                                    if (seasonMeta != null) {
+                                        if (season.getTitle() == null && seasonMeta.has("name")) season.setTitle(seasonMeta.getString("name"));
+                                        // Enrich episodes
+                                        if (season.getEpisodes() != null) {
+                                            for (Episode episode : season.getEpisodes()) {
+                                                JSONObject episodeMeta = TmdbMetadataUtil.fetchTvEpisodeMetadata(tmdbId, season.getId(), episode.getId(), tmdbApiKey);
+                                                if (episodeMeta != null) {
+                                                    if (episode.getTitle() == null && episodeMeta.has("name")) episode.setTitle(episodeMeta.getString("name"));
+                                                    if (episode.getDescription() == null && episodeMeta.has("overview")) episode.setDescription(episodeMeta.getString("overview"));
+                                                    if (episode.getImage() == null && episodeMeta.has("still_path")) episode.setImage("https://image.tmdb.org/t/p/w500" + episodeMeta.getString("still_path"));
+                                                    if (episode.getDuration() == null && episodeMeta.has("runtime")) episode.setDuration(String.valueOf(episodeMeta.getInt("runtime")));
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 } catch (Exception ignored) {}
             }
         }

--- a/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
@@ -38,6 +38,12 @@ import timber.log.Timber;
 import static okhttp3.logging.HttpLoggingInterceptor.Level.HEADERS;
 import static okhttp3.logging.HttpLoggingInterceptor.Level.NONE;
 
+import my.cinemax.app.free.Utils.TmdbMetadataUtil;
+import org.json.JSONObject;
+
+import java.util.Properties;
+import java.io.FileInputStream;
+
 /**
  * Created by Tamim on 28/09/2019.
  * Updated to use GitHub JSON API exclusively
@@ -282,6 +288,9 @@ public class apiClient {
                 
                 if (response.isSuccessful() && response.body() != null) {
                     Log.d("API_CLIENT", "Successfully loaded JSON data");
+                    // Enrich metadata with TMDB
+                    String tmdbApiKey = getTmdbApiKey();
+                    enrichMetadataWithTmdb(response.body(), tmdbApiKey);
                     callback.onSuccess(response.body());
                 } else {
                     String errorMsg = "Failed to load data from GitHub JSON API. Response code: " + response.code();
@@ -304,6 +313,47 @@ public class apiClient {
                 callback.onError(errorMsg);
             }
         });
+    }
+
+    private static String getTmdbApiKey() {
+        try {
+            Properties properties = new Properties();
+            properties.load(new FileInputStream("/workspace/CineMax/local.properties"));
+            return properties.getProperty("tmdb_api_key", "");
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    /**
+     * Enriches movie and TV metadata using TMDB for missing fields.
+     * This should be called after loading the JSON API data.
+     */
+    public static void enrichMetadataWithTmdb(JsonApiResponse apiResponse, String tmdbApiKey) {
+        if (apiResponse == null) return;
+        // Enrich movies
+        if (apiResponse.getMovies() != null) {
+            for (Poster movie : apiResponse.getMovies()) {
+                try {
+                    if (movie.getImdb() == null || movie.getDescription() == null || movie.getImage() == null) {
+                        Integer tmdbId = null;
+                        try { tmdbId = Integer.valueOf(movie.getId()); } catch (Exception ignore) {}
+                        if (tmdbId != null) {
+                            JSONObject meta = TmdbMetadataUtil.fetchMovieMetadata(tmdbId, tmdbApiKey);
+                            if (meta != null) {
+                                if (movie.getDescription() == null && meta.has("overview")) movie.setDescription(meta.getString("overview"));
+                                if (movie.getImage() == null && meta.has("poster_path")) movie.setImage("https://image.tmdb.org/t/p/w500" + meta.getString("poster_path"));
+                                if (movie.getCover() == null && meta.has("backdrop_path")) movie.setCover("https://image.tmdb.org/t/p/w780" + meta.getString("backdrop_path"));
+                                if (movie.getYear() == null && meta.has("release_date")) movie.setYear(meta.getString("release_date"));
+                                if (movie.getRating() == null && meta.has("vote_average")) movie.setRating((float) meta.getDouble("vote_average"));
+                            }
+                        }
+                    }
+                } catch (Exception ignored) {}
+            }
+        }
+        // Enrich TV series (if you have a similar list for TV)
+        // TODO: Add similar logic for TV series and episodes if your data model supports it
     }
 
     /**

--- a/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
@@ -353,7 +353,26 @@ public class apiClient {
             }
         }
         // Enrich TV series (if you have a similar list for TV)
-        // TODO: Add similar logic for TV series and episodes if your data model supports it
+        if (apiResponse.getCategories() != null) {
+            for (Object tvObj : apiResponse.getCategories()) {
+                try {
+                    // This assumes your TV series objects have a getMeta() method with tmdb_id, seasons, etc.
+                    // You may need to adjust this based on your actual data model.
+                    // Pseudocode for enrichment:
+                    // 1. Fetch series metadata
+                    // 2. For each season, fetch season metadata
+                    // 3. For each episode, fetch episode metadata
+                    // Example assumes a structure similar to the JSON you provided
+                    // (You may need to cast or adapt this for your actual model)
+                    // JSONObject meta = ...
+                    // int tmdbId = meta.getInt("tmdb_id");
+                    // JSONObject seriesMeta = TmdbMetadataUtil.fetchTvMetadata(tmdbId, tmdbApiKey);
+                    // ... fill series fields ...
+                    // JSONArray seasons = meta.getJSONArray("seasons");
+                    // for (int i = 0; i < seasons.length(); i++) { ... fetch season ... for each episode ... fetch episode ... }
+                } catch (Exception ignored) {}
+            }
+        }
     }
 
     /**

--- a/CineMax/app/src/main/java/my/cinemax/app/free/entity/Poster.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/entity/Poster.java
@@ -100,6 +100,10 @@ public class Poster implements Parcelable {
     @Expose
     private Source trailer ;
 
+    @SerializedName("seasons")
+    @Expose
+    private List<Season> seasons;
+
     private int typeView = 1;
 
     public Poster() {
@@ -391,6 +395,14 @@ public class Poster implements Parcelable {
 
     public String getSublabel() {
         return sublabel;
+    }
+
+    public List<Season> getSeasons() {
+        return seasons;
+    }
+
+    public void setSeasons(List<Season> seasons) {
+        this.seasons = seasons;
     }
 }
 


### PR DESCRIPTION
Add `free_movie_api.json` with movie and TV series examples, structured for TMDB metadata integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-fde6513e-3745-4dc5-ad86-2ea0fbcf6390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fde6513e-3745-4dc5-ad86-2ea0fbcf6390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>