### PR TITLE
Integrate tmdb auto metadata for movies and series

### DIFF
--- a/CineMax/app/src/main/java/my/cinemax/app/free/api/TMDBMetadataManager.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/api/TMDBMetadataManager.java
@@ -1,0 +1,327 @@
+package my.cinemax.app.free.api;
+
+import android.util.Log;
+import my.cinemax.app.free.entity.Poster;
+import my.cinemax.app.free.entity.Actor;
+import my.cinemax.app.free.entity.Genre;
+import my.cinemax.app.free.entity.JsonApiResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * TMDB Metadata Manager for auto-enhancing movie and series data
+ * This class integrates with the existing JSON API to automatically
+ * fill missing metadata using TMDB API
+ */
+public class TMDBMetadataManager {
+    
+    private static final String TAG = "TMDBMetadataManager";
+    private static TMDBMetadataManager instance;
+    private TMDBService tmdbService;
+    
+    private TMDBMetadataManager() {
+        tmdbService = TMDBService.getInstance();
+    }
+    
+    public static TMDBMetadataManager getInstance() {
+        if (instance == null) {
+            instance = new TMDBMetadataManager();
+        }
+        return instance;
+    }
+    
+    /**
+     * Enhance movie data with TMDB metadata if missing
+     */
+    public void enhanceMovieData(Poster movie, TMDBEnhancementCallback callback) {
+        // Check if movie needs enhancement (missing description, actors, etc.)
+        if (needsEnhancement(movie)) {
+            Log.d(TAG, "Enhancing movie: " + movie.getTitle());
+            
+            tmdbService.searchMovie(movie.getTitle(), new TMDBService.TMDBMovieCallback() {
+                @Override
+                public void onSuccess(TMDBService.TMDBMovieData tmdbData) {
+                    enhanceMovieWithTMDBData(movie, tmdbData);
+                    callback.onSuccess(movie);
+                }
+                
+                @Override
+                public void onError(String error) {
+                    Log.w(TAG, "Failed to enhance movie " + movie.getTitle() + ": " + error);
+                    callback.onError(error);
+                }
+            });
+        } else {
+            // Movie already has complete data
+            callback.onSuccess(movie);
+        }
+    }
+    
+    /**
+     * Enhance TV series data with TMDB metadata if missing
+     */
+    public void enhanceTVSeriesData(Poster series, TMDBEnhancementCallback callback) {
+        // Check if series needs enhancement
+        if (needsEnhancement(series)) {
+            Log.d(TAG, "Enhancing TV series: " + series.getTitle());
+            
+            tmdbService.searchTVSeries(series.getTitle(), new TMDBService.TMDBTVCallback() {
+                @Override
+                public void onSuccess(TMDBService.TMDBTVData tmdbData) {
+                    enhanceSeriesWithTMDBData(series, tmdbData);
+                    callback.onSuccess(series);
+                }
+                
+                @Override
+                public void onError(String error) {
+                    Log.w(TAG, "Failed to enhance series " + series.getTitle() + ": " + error);
+                    callback.onError(error);
+                }
+            });
+        } else {
+            // Series already has complete data
+            callback.onSuccess(series);
+        }
+    }
+    
+    /**
+     * Enhance all movies in the JSON response
+     */
+    public void enhanceAllMovies(JsonApiResponse jsonResponse, TMDBEnhancementCallback callback) {
+        if (jsonResponse.getMovies() != null) {
+            List<Poster> movies = jsonResponse.getMovies();
+            final int[] enhancedCount = {0};
+            final int totalMovies = movies.size();
+            
+            for (Poster movie : movies) {
+                enhanceMovieData(movie, new TMDBEnhancementCallback() {
+                    @Override
+                    public void onSuccess(Poster enhancedItem) {
+                        enhancedCount[0]++;
+                        if (enhancedCount[0] == totalMovies) {
+                            callback.onSuccess(null); // All movies enhanced
+                        }
+                    }
+                    
+                    @Override
+                    public void onError(String error) {
+                        enhancedCount[0]++;
+                        if (enhancedCount[0] == totalMovies) {
+                            callback.onSuccess(null); // Continue even if some fail
+                        }
+                    }
+                });
+            }
+        } else {
+            callback.onSuccess(null);
+        }
+    }
+    
+    /**
+     * Check if a movie/series needs enhancement
+     */
+    private boolean needsEnhancement(Poster item) {
+        // Check if description is missing or too short
+        if (item.getDescription() == null || item.getDescription().isEmpty() || 
+            item.getDescription().length() < 50) {
+            return true;
+        }
+        
+        // Check if actors list is empty or missing
+        if (item.getActors() == null || item.getActors().isEmpty()) {
+            return true;
+        }
+        
+        // Check if genres are missing or incomplete
+        if (item.getGenres() == null || item.getGenres().isEmpty()) {
+            return true;
+        }
+        
+        // Check if IMDB ID is missing
+        if (item.getImdb() == null || item.getImdb().isEmpty() || 
+            !item.getImdb().startsWith("tt")) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Enhance movie with TMDB data
+     */
+    private void enhanceMovieWithTMDBData(Poster movie, TMDBService.TMDBMovieData tmdbData) {
+        // Update description if missing or too short
+        if (movie.getDescription() == null || movie.getDescription().isEmpty() || 
+            movie.getDescription().length() < 50) {
+            movie.setDescription(tmdbData.overview);
+        }
+        
+        // Update IMDB ID if missing
+        if (movie.getImdb() == null || movie.getImdb().isEmpty() || 
+            !movie.getImdb().startsWith("tt")) {
+            movie.setImdb(tmdbData.imdbId);
+        }
+        
+        // Update rating if missing
+        if (movie.getRating() == 0.0f) {
+            movie.setRating((float) tmdbData.voteAverage);
+        }
+        
+        // Update year if missing
+        if (movie.getYear() == null || movie.getYear().isEmpty()) {
+            if (tmdbData.releaseDate != null && tmdbData.releaseDate.length() >= 4) {
+                movie.setYear(tmdbData.releaseDate.substring(0, 4));
+            }
+        }
+        
+        // Update duration if missing
+        if (movie.getDuration() == null || movie.getDuration().isEmpty()) {
+            if (tmdbData.runtime > 0) {
+                int hours = tmdbData.runtime / 60;
+                int minutes = tmdbData.runtime % 60;
+                movie.setDuration(String.format("%d:%02d", hours, minutes));
+            }
+        }
+        
+        // Update genres if missing
+        if (movie.getGenres() == null || movie.getGenres().isEmpty()) {
+            List<Genre> genres = new ArrayList<>();
+            for (int i = 0; i < tmdbData.genres.size(); i++) {
+                Genre genre = new Genre();
+                genre.setId(i + 1);
+                genre.setTitle(tmdbData.genres.get(i));
+                genres.add(genre);
+            }
+            movie.setGenres(genres);
+        }
+        
+        // Update actors if missing
+        if (movie.getActors() == null || movie.getActors().isEmpty()) {
+            List<Actor> actors = new ArrayList<>();
+            for (int i = 0; i < Math.min(tmdbData.cast.size(), 5); i++) {
+                TMDBService.TMDBMovieData.Actor tmdbActor = tmdbData.cast.get(i);
+                Actor actor = new Actor();
+                actor.setId(i + 1);
+                actor.setName(tmdbActor.name);
+                actor.setRole(tmdbActor.character);
+                actor.setType("actor");
+                // Don't set image - keep original images untouched
+                actors.add(actor);
+            }
+            movie.setActors(actors);
+        }
+        
+        Log.d(TAG, "Enhanced movie: " + movie.getTitle());
+    }
+    
+    /**
+     * Enhance TV series with TMDB data
+     */
+    private void enhanceSeriesWithTMDBData(Poster series, TMDBService.TMDBTVData tmdbData) {
+        // Update description if missing or too short
+        if (series.getDescription() == null || series.getDescription().isEmpty() || 
+            series.getDescription().length() < 50) {
+            series.setDescription(tmdbData.overview);
+        }
+        
+        // Update rating if missing
+        if (series.getRating() == 0.0f) {
+            series.setRating((float) tmdbData.voteAverage);
+        }
+        
+        // Update year if missing
+        if (series.getYear() == null || series.getYear().isEmpty()) {
+            if (tmdbData.firstAirDate != null && tmdbData.firstAirDate.length() >= 4) {
+                series.setYear(tmdbData.firstAirDate.substring(0, 4));
+            }
+        }
+        
+        // Update genres if missing
+        if (series.getGenres() == null || series.getGenres().isEmpty()) {
+            List<Genre> genres = new ArrayList<>();
+            for (int i = 0; i < tmdbData.genres.size(); i++) {
+                Genre genre = new Genre();
+                genre.setId(i + 1);
+                genre.setTitle(tmdbData.genres.get(i));
+                genres.add(genre);
+            }
+            series.setGenres(genres);
+        }
+        
+        // Update actors if missing
+        if (series.getActors() == null || series.getActors().isEmpty()) {
+            List<Actor> actors = new ArrayList<>();
+            for (int i = 0; i < Math.min(tmdbData.cast.size(), 5); i++) {
+                TMDBService.TMDBTVData.Actor tmdbActor = tmdbData.cast.get(i);
+                Actor actor = new Actor();
+                actor.setId(i + 1);
+                actor.setName(tmdbActor.name);
+                actor.setRole(tmdbActor.character);
+                actor.setType("actor");
+                // Don't set image - keep original images untouched
+                actors.add(actor);
+            }
+            series.setActors(actors);
+        }
+        
+        Log.d(TAG, "Enhanced TV series: " + series.getTitle());
+    }
+    
+    /**
+     * Auto-enhance all content in JSON response
+     */
+    public void autoEnhanceJsonResponse(JsonApiResponse jsonResponse, TMDBEnhancementCallback callback) {
+        Log.d(TAG, "Starting auto-enhancement of JSON response");
+        
+        // Enhance movies
+        if (jsonResponse.getMovies() != null) {
+            Log.d(TAG, "Found " + jsonResponse.getMovies().size() + " movies/series to process");
+            
+            for (Poster movie : jsonResponse.getMovies()) {
+                if ("movie".equals(movie.getType())) {
+                    Log.d(TAG, "Processing movie: " + movie.getTitle());
+                    enhanceMovieData(movie, new TMDBEnhancementCallback() {
+                        @Override
+                        public void onSuccess(Poster enhancedItem) {
+                            Log.d(TAG, "Movie enhanced successfully: " + enhancedItem.getTitle());
+                        }
+                        
+                        @Override
+                        public void onError(String error) {
+                            Log.w(TAG, "Failed to enhance movie " + movie.getTitle() + ": " + error);
+                        }
+                    });
+                } else if ("series".equals(movie.getType())) {
+                    Log.d(TAG, "Processing TV series: " + movie.getTitle());
+                    enhanceTVSeriesData(movie, new TMDBEnhancementCallback() {
+                        @Override
+                        public void onSuccess(Poster enhancedItem) {
+                            Log.d(TAG, "TV series enhanced successfully: " + enhancedItem.getTitle());
+                        }
+                        
+                        @Override
+                        public void onError(String error) {
+                            Log.w(TAG, "Failed to enhance TV series " + movie.getTitle() + ": " + error);
+                        }
+                    });
+                } else {
+                    Log.d(TAG, "Skipping item with type: " + movie.getType() + " - " + movie.getTitle());
+                }
+            }
+        } else {
+            Log.d(TAG, "No movies found in JSON response");
+        }
+        
+        // Don't touch channels (Live TV) as requested
+        Log.d(TAG, "Auto-enhancement completed - channels left untouched");
+        callback.onSuccess(null);
+    }
+    
+    /**
+     * Callback interface for enhancement operations
+     */
+    public interface TMDBEnhancementCallback {
+        void onSuccess(Poster enhancedItem);
+        void onError(String error);
+    }
+}

--- a/CineMax/app/src/main/java/my/cinemax/app/free/api/TMDBService.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/api/TMDBService.java
@@ -1,0 +1,348 @@
+package my.cinemax.app.free.api;
+
+import android.util.Log;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * TMDB API Service for auto-detecting movie and series metadata
+ */
+public class TMDBService {
+    
+    private static final String TAG = "TMDBService";
+    private static final String TMDB_API_KEY = "ec926176bf467b3f7735e3154238c161";
+    private static final String TMDB_BASE_URL = "https://api.themoviedb.org/3/";
+    private static TMDBService instance;
+    private TMDBApiInterface apiInterface;
+    
+    private TMDBService() {
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .build();
+        
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(TMDB_BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+        
+        apiInterface = retrofit.create(TMDBApiInterface.class);
+    }
+    
+    public static TMDBService getInstance() {
+        if (instance == null) {
+            instance = new TMDBService();
+        }
+        return instance;
+    }
+    
+    /**
+     * Search for a movie by title
+     */
+    public void searchMovie(String title, TMDBMovieCallback callback) {
+        Call<JsonObject> call = apiInterface.searchMovie(TMDB_API_KEY, title);
+        call.enqueue(new Callback<JsonObject>() {
+            @Override
+            public void onResponse(Call<JsonObject> call, retrofit2.Response<JsonObject> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    try {
+                        JsonObject jsonResponse = response.body();
+                        if (jsonResponse.has("results") && jsonResponse.getAsJsonArray("results").size() > 0) {
+                            JsonObject movie = jsonResponse.getAsJsonArray("results").get(0).getAsJsonObject();
+                            callback.onSuccess(parseMovieData(movie));
+                        } else {
+                            callback.onError("No movie found for: " + title);
+                        }
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error parsing movie response", e);
+                        callback.onError("Error parsing movie data");
+                    }
+                } else {
+                    callback.onError("Failed to fetch movie data");
+                }
+            }
+            
+            @Override
+            public void onFailure(Call<JsonObject> call, Throwable t) {
+                Log.e(TAG, "Movie search failed", t);
+                callback.onError("Network error: " + t.getMessage());
+            }
+        });
+    }
+    
+    /**
+     * Search for a TV series by title
+     */
+    public void searchTVSeries(String title, TMDBTVCallback callback) {
+        Call<JsonObject> call = apiInterface.searchTVSeries(TMDB_API_KEY, title);
+        call.enqueue(new Callback<JsonObject>() {
+            @Override
+            public void onResponse(Call<JsonObject> call, retrofit2.Response<JsonObject> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    try {
+                        JsonObject jsonResponse = response.body();
+                        if (jsonResponse.has("results") && jsonResponse.getAsJsonArray("results").size() > 0) {
+                            JsonObject series = jsonResponse.getAsJsonArray("results").get(0).getAsJsonObject();
+                            callback.onSuccess(parseTVData(series));
+                        } else {
+                            callback.onError("No TV series found for: " + title);
+                        }
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error parsing TV series response", e);
+                        callback.onError("Error parsing TV series data");
+                    }
+                } else {
+                    callback.onError("Failed to fetch TV series data");
+                }
+            }
+            
+            @Override
+            public void onFailure(Call<JsonObject> call, Throwable t) {
+                Log.e(TAG, "TV series search failed", t);
+                callback.onError("Network error: " + t.getMessage());
+            }
+        });
+    }
+    
+    /**
+     * Get detailed movie information including credits
+     */
+    public void getMovieDetails(int movieId, TMDBMovieCallback callback) {
+        Call<JsonObject> call = apiInterface.getMovieDetails(movieId, TMDB_API_KEY, "credits");
+        call.enqueue(new Callback<JsonObject>() {
+            @Override
+            public void onResponse(Call<JsonObject> call, retrofit2.Response<JsonObject> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    try {
+                        JsonObject movie = response.body();
+                        callback.onSuccess(parseMovieData(movie));
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error parsing movie details", e);
+                        callback.onError("Error parsing movie details");
+                    }
+                } else {
+                    callback.onError("Failed to fetch movie details");
+                }
+            }
+            
+            @Override
+            public void onFailure(Call<JsonObject> call, Throwable t) {
+                Log.e(TAG, "Movie details fetch failed", t);
+                callback.onError("Network error: " + t.getMessage());
+            }
+        });
+    }
+    
+    /**
+     * Get detailed TV series information including credits
+     */
+    public void getTVSeriesDetails(int seriesId, TMDBTVCallback callback) {
+        Call<JsonObject> call = apiInterface.getTVSeriesDetails(seriesId, TMDB_API_KEY, "credits");
+        call.enqueue(new Callback<JsonObject>() {
+            @Override
+            public void onResponse(Call<JsonObject> call, retrofit2.Response<JsonObject> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    try {
+                        JsonObject series = response.body();
+                        callback.onSuccess(parseTVData(series));
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error parsing TV series details", e);
+                        callback.onError("Error parsing TV series details");
+                    }
+                } else {
+                    callback.onError("Failed to fetch TV series details");
+                }
+            }
+            
+            @Override
+            public void onFailure(Call<JsonObject> call, Throwable t) {
+                Log.e(TAG, "TV series details fetch failed", t);
+                callback.onError("Network error: " + t.getMessage());
+            }
+        });
+    }
+    
+    /**
+     * Parse movie data from TMDB response
+     */
+    private TMDBMovieData parseMovieData(JsonObject movie) {
+        TMDBMovieData data = new TMDBMovieData();
+        
+        try {
+            data.id = movie.has("id") ? movie.get("id").getAsInt() : 0;
+            data.title = movie.has("title") ? movie.get("title").getAsString() : "";
+            data.originalTitle = movie.has("original_title") ? movie.get("original_title").getAsString() : "";
+            data.overview = movie.has("overview") ? movie.get("overview").getAsString() : "";
+            data.releaseDate = movie.has("release_date") ? movie.get("release_date").getAsString() : "";
+            data.runtime = movie.has("runtime") ? movie.get("runtime").getAsInt() : 0;
+            data.voteAverage = movie.has("vote_average") ? movie.get("vote_average").getAsDouble() : 0.0;
+            data.voteCount = movie.has("vote_count") ? movie.get("vote_count").getAsInt() : 0;
+            data.imdbId = movie.has("imdb_id") ? movie.get("imdb_id").getAsString() : "";
+            
+            // Parse genres
+            if (movie.has("genres") && movie.get("genres").isJsonArray()) {
+                for (int i = 0; i < movie.getAsJsonArray("genres").size(); i++) {
+                    JsonObject genre = movie.getAsJsonArray("genres").get(i).getAsJsonObject();
+                    data.genres.add(genre.get("name").getAsString());
+                }
+            }
+            
+            // Parse cast
+            if (movie.has("credits") && movie.get("credits").isJsonObject()) {
+                JsonObject credits = movie.getAsJsonObject("credits");
+                if (credits.has("cast") && credits.get("cast").isJsonArray()) {
+                    for (int i = 0; i < Math.min(credits.getAsJsonArray("cast").size(), 10); i++) {
+                        JsonObject actor = credits.getAsJsonArray("cast").get(i).getAsJsonObject();
+                        TMDBMovieData.Actor actorData = new TMDBMovieData.Actor();
+                        actorData.name = actor.has("name") ? actor.get("name").getAsString() : "";
+                        actorData.character = actor.has("character") ? actor.get("character").getAsString() : "";
+                        actorData.profilePath = actor.has("profile_path") ? actor.get("profile_path").getAsString() : "";
+                        data.cast.add(actorData);
+                    }
+                }
+            }
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error parsing movie data", e);
+        }
+        
+        return data;
+    }
+    
+    /**
+     * Parse TV series data from TMDB response
+     */
+    private TMDBTVData parseTVData(JsonObject series) {
+        TMDBTVData data = new TMDBTVData();
+        
+        try {
+            data.id = series.has("id") ? series.get("id").getAsInt() : 0;
+            data.name = series.has("name") ? series.get("name").getAsString() : "";
+            data.originalName = series.has("original_name") ? series.get("original_name").getAsString() : "";
+            data.overview = series.has("overview") ? series.get("overview").getAsString() : "";
+            data.firstAirDate = series.has("first_air_date") ? series.get("first_air_date").getAsString() : "";
+            data.voteAverage = series.has("vote_average") ? series.get("vote_average").getAsDouble() : 0.0;
+            data.voteCount = series.has("vote_count") ? series.get("vote_count").getAsInt() : 0;
+            data.numberOfSeasons = series.has("number_of_seasons") ? series.get("number_of_seasons").getAsInt() : 0;
+            data.numberOfEpisodes = series.has("number_of_episodes") ? series.get("number_of_episodes").getAsInt() : 0;
+            
+            // Parse genres
+            if (series.has("genres") && series.get("genres").isJsonArray()) {
+                for (int i = 0; i < series.getAsJsonArray("genres").size(); i++) {
+                    JsonObject genre = series.getAsJsonArray("genres").get(i).getAsJsonObject();
+                    data.genres.add(genre.get("name").getAsString());
+                }
+            }
+            
+            // Parse cast
+            if (series.has("credits") && series.get("credits").isJsonObject()) {
+                JsonObject credits = series.getAsJsonObject("credits");
+                if (credits.has("cast") && credits.get("cast").isJsonArray()) {
+                    for (int i = 0; i < Math.min(credits.getAsJsonArray("cast").size(), 10); i++) {
+                        JsonObject actor = credits.getAsJsonArray("cast").get(i).getAsJsonObject();
+                        TMDBTVData.Actor actorData = new TMDBTVData.Actor();
+                        actorData.name = actor.has("name") ? actor.get("name").getAsString() : "";
+                        actorData.character = actor.has("character") ? actor.get("character").getAsString() : "";
+                        actorData.profilePath = actor.has("profile_path") ? actor.get("profile_path").getAsString() : "";
+                        data.cast.add(actorData);
+                    }
+                }
+            }
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error parsing TV series data", e);
+        }
+        
+        return data;
+    }
+    
+    /**
+     * TMDB API Interface
+     */
+    public interface TMDBApiInterface {
+        @GET("search/movie")
+        Call<JsonObject> searchMovie(@Query("api_key") String apiKey, @Query("query") String query);
+        
+        @GET("search/tv")
+        Call<JsonObject> searchTVSeries(@Query("api_key") String apiKey, @Query("query") String query);
+        
+        @GET("movie/{movie_id}")
+        Call<JsonObject> getMovieDetails(@Path("movie_id") int movieId, @Query("api_key") String apiKey, @Query("append_to_response") String appendToResponse);
+        
+        @GET("tv/{tv_id}")
+        Call<JsonObject> getTVSeriesDetails(@Path("tv_id") int seriesId, @Query("api_key") String apiKey, @Query("append_to_response") String appendToResponse);
+    }
+    
+    /**
+     * Callback interfaces
+     */
+    public interface TMDBMovieCallback {
+        void onSuccess(TMDBMovieData movieData);
+        void onError(String error);
+    }
+    
+    public interface TMDBTVCallback {
+        void onSuccess(TMDBTVData tvData);
+        void onError(String error);
+    }
+    
+    /**
+     * Movie data class
+     */
+    public static class TMDBMovieData {
+        public int id;
+        public String title;
+        public String originalTitle;
+        public String overview;
+        public String releaseDate;
+        public int runtime;
+        public double voteAverage;
+        public int voteCount;
+        public String imdbId;
+        public java.util.List<String> genres = new java.util.ArrayList<>();
+        public java.util.List<Actor> cast = new java.util.ArrayList<>();
+        
+        public static class Actor {
+            public String name;
+            public String character;
+            public String profilePath;
+        }
+    }
+    
+    /**
+     * TV series data class
+     */
+    public static class TMDBTVData {
+        public int id;
+        public String name;
+        public String originalName;
+        public String overview;
+        public String firstAirDate;
+        public double voteAverage;
+        public int voteCount;
+        public int numberOfSeasons;
+        public int numberOfEpisodes;
+        public java.util.List<String> genres = new java.util.ArrayList<>();
+        public java.util.List<Actor> cast = new java.util.ArrayList<>();
+        
+        public static class Actor {
+            public String name;
+            public String character;
+            public String profilePath;
+        }
+    }
+}

--- a/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/api/apiClient.java
@@ -159,7 +159,35 @@ public class apiClient {
         Retrofit retrofit = getClient();
         apiRest service = retrofit.create(apiRest.class);
         Call<JsonApiResponse> call = service.getJsonApiData();
-        call.enqueue(callback);
+        call.enqueue(new Callback<JsonApiResponse>() {
+            @Override
+            public void onResponse(Call<JsonApiResponse> call, retrofit2.Response<JsonApiResponse> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    // Auto-enhance with TMDB metadata
+                    TMDBMetadataManager.getInstance().autoEnhanceJsonResponse(response.body(), 
+                        new TMDBMetadataManager.TMDBEnhancementCallback() {
+                            @Override
+                            public void onSuccess(Poster enhancedItem) {
+                                // Continue with original callback
+                                callback.onResponse(call, response);
+                            }
+                            
+                            @Override
+                            public void onError(String error) {
+                                // Continue even if enhancement fails
+                                callback.onResponse(call, response);
+                            }
+                        });
+                } else {
+                    callback.onResponse(call, response);
+                }
+            }
+            
+            @Override
+            public void onFailure(Call<JsonApiResponse> call, Throwable t) {
+                callback.onFailure(call, t);
+            }
+        });
     }
     
     /**

--- a/free_movie_api.json
+++ b/free_movie_api.json
@@ -331,8 +331,8 @@
         "rating": 6.5,
         "views": 15000,
         "created_at": "2024-01-01",
-        "image": "",
-        "cover": "",
+        "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
+        "cover": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
         "genres": [
           { "id": 6, "title": "Animation" },
           { "id": 35, "title": "Comedy" },
@@ -615,8 +615,8 @@
       "rating": 8.2,
       "views": 8000,
       "created_at": "2024-01-02",
-      "image": "",
-      "cover": "",
+      "image": "https://example.com/sample-series.jpg",
+      "cover": "https://example.com/sample-series-cover.jpg",
       "genres": [
         { "id": 3, "title": "Drama" }
       ],
@@ -646,7 +646,7 @@
               "id": 1,
               "title": "Episode 1",
               "episode_number": 1,
-              "image": "",
+              "image": "https://example.com/ep1.jpg",
               "duration": "45:00",
               "sources": [
                 {

--- a/free_movie_api.json
+++ b/free_movie_api.json
@@ -1,0 +1,1985 @@
+{
+  "api_info": {
+    "version": "2.0",
+    "description": "Enhanced Free Movie & TV Streaming JSON API with Full Actor Support",
+    "last_updated": "2024-01-15",
+    "total_movies": 2,
+    "total_channels": 26,
+    "total_actors": 2
+  },
+  "home": {
+    "slides": [
+      {
+        "id": 1,
+        "title": "Big Buck Bunny",
+        "type": "movie",
+        "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
+        "url": "movies/1",
+        "poster": {
+          "id": 1,
+          "title": "Big Buck Bunny",
+          "type": "movie",
+          "label": "Animation",
+          "sublabel": "Short Film",
+          "imdb": "8.5",
+          "downloadas": "big-buck-bunny.mp4",
+          "comment": true,
+          "playas": "video",
+          "description": "Big Buck Bunny tells the story of a giant rabbit with a heart bigger than himself. When one sunny day three rodents rudely harass him by throwing nuts, hitting his flowers, and destroying his home, he snaps and goes after them.",
+          "classification": "G",
+          "year": "2008",
+          "duration": "10:00",
+          "rating": 8.5,
+          "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
+          "cover": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
+          "genres": [
+            {
+              "id": 6,
+              "title": "Animation"
+            }
+          ],
+          "sources": [
+            {
+              "id": 1,
+              "type": "video",
+              "title": "Big Buck Bunny 1080p",
+              "quality": "1080p",
+              "size": "264MB",
+              "kind": "both",
+              "premium": "false",
+              "external": false,
+              "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+            },
+            {
+              "id": 2,
+              "type": "video",
+              "title": "Big Buck Bunny 720p",
+              "quality": "720p",
+              "size": "128MB",
+              "kind": "both",
+              "premium": "false",
+              "external": false,
+              "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+            },
+            {
+              "id": 3,
+              "type": "video",
+              "title": "Big Buck Bunny 480p",
+              "quality": "480p",
+              "size": "64MB",
+              "kind": "both",
+              "premium": "false",
+              "external": false,
+              "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+            }
+          ],
+          "trailer": {
+            "id": 4,
+            "type": "video",
+            "title": "Big Buck Bunny Trailer",
+            "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+          },
+          "actors": [
+            {
+              "id": 1,
+              "name": "Tom Hanks",
+              "type": "actor",
+              "role": "Lead Actor",
+              "image": "https://example.com/tom-hanks.jpg",
+              "born": "1956-07-09",
+              "height": "6'0\"",
+              "bio": "American actor and filmmaker"
+            }
+          ],
+          "subtitles": [
+            {
+              "id": 1,
+              "title": "English",
+              "language": "en",
+              "url": "https://example.com/subtitles/big-buck-bunny-en.vtt"
+            },
+            {
+              "id": 2,
+              "title": "Spanish",
+              "language": "es",
+              "url": "https://example.com/subtitles/big-buck-bunny-es.vtt"
+            }
+          ],
+          "comments": [
+            {
+              "id": 1,
+              "user": "John Doe",
+              "comment": "Amazing animation! Love this movie.",
+              "created_at": "2024-01-15T10:30:00Z"
+            },
+            {
+              "id": 2,
+              "user": "Jane Smith",
+              "comment": "Great for kids and adults alike!",
+              "created_at": "2024-01-14T15:45:00Z"
+            }
+          ],
+          "views": 15000,
+          "downloads": 5000,
+          "shares": 1200
+        }
+      },
+      {
+        "id": 1,
+        "title": "AZ2",
+        "type": "channel",
+        "image": "https://i.imgur.com/1zsdloF.png",
+        "url": "channels/1",
+        "channel": {
+          "id": 1,
+          "title": "AZ2",
+          "label": "Entertainment",
+          "sublabel": "Philippines",
+          "description": "AZ2",
+          "website": "https://example-news.com",
+          "classification": "News",
+          "views": 25000,
+          "shares": 800,
+          "rating": 7.8,
+          "comment": true,
+          "image": "https://i.imgur.com/1zsdloF.png",
+          "playas": "live",
+          "sources": [
+            {
+              "id": 6,
+              "type": "live",
+              "title": "720p",
+              "quality": "720p",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_5.m3u8"
+            },
+            {
+              "id": 7,
+              "type": "live",
+              "title": "480p",
+              "quality": "480p",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_4.m3u8"
+            },
+            {
+              "id": 8,
+              "type": "live",
+              "title": "360p",
+              "quality": "360p",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_3.m3u8"
+            },
+            {
+              "id": 9,
+              "type": "live",
+              "title": "240p",
+              "quality": "240p",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_2.m3u8"
+            },
+            {
+              "id": 10,
+              "type": "live",
+              "title": "144p",
+              "quality": "144p",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_1.m3u8"
+            }
+          ],
+          "categories": [
+            {
+              "id": 3,
+              "title": "Entertainment"
+            }
+          ],
+          "countries": [
+            {
+              "id": 1,
+              "title": "PH"
+            }
+          ],
+          "comments": []
+        }
+      },
+      {
+        "id": 2,
+        "title": "Cine Mo!",
+        "type": "channel",
+        "image": "https://i.imgur.com/KUwrSOH.png",
+        "url": "channels/2",
+        "channel": {
+          "id": 2,
+          "title": "Cine Mo!",
+          "label": "Movies",
+          "sublabel": "PH",
+          "description": "Cine Mo! is a Filipino pay television channel owned by ABS-CBN.",
+          "website": "https://example-news.com",
+          "classification": "Movies",
+          "views": 0,
+          "shares": 0,
+          "rating": 0,
+          "comment": true,
+          "image": "https://i.imgur.com/KUwrSOH.png",
+          "playas": "live",
+          "sources": [
+            {
+              "id": 11,
+              "type": "live",
+              "title": "HD",
+              "quality": "HD",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://d1bail49udbz1k.cloudfront.net/out/v1/78e282e04f0944f3ad0aa1db7a1be645/index.m3u8"
+            }
+          ],
+          "categories": [
+            {
+              "id": 5,
+              "title": "Movies"
+            }
+          ],
+          "countries": [
+            {
+              "id": 1,
+              "title": "PH"
+            }
+          ],
+          "comments": []
+        }
+      },
+      {
+        "id": 3,
+        "title": "Kapamilya Channel",
+        "type": "channel",
+        "image": "https://i.imgur.com/Dcys2TG.png",
+        "url": "channels/3",
+        "channel": {
+          "id": 3,
+          "title": "Kapamilya Channel",
+          "label": "General",
+          "sublabel": "PH",
+          "description": "",
+          "website": "https://example-news.com",
+          "classification": "General",
+          "views": 0,
+          "shares": 0,
+          "rating": 8,
+          "comment": true,
+          "image": "https://i.imgur.com/Dcys2TG.png",
+          "playas": "live",
+          "sources": [
+            {
+              "id": 12,
+              "type": "live",
+              "title": "Live",
+              "quality": "HD",
+              "size": "Live",
+              "kind": "play",
+              "premium": "false",
+              "external": false,
+              "url": "https://live-faws.akamaized.net/out/v1/df7b60b4411f4270ab431913de807bf4/index.m3u8"
+            }
+          ],
+          "categories": [
+            {
+              "id": 6,
+              "title": "General"
+            }
+          ],
+          "countries": [
+            {
+              "id": 1,
+              "title": "PH"
+            }
+          ],
+          "comments": []
+        }
+      }
+    ],
+    "featured_movies": [
+      {
+        "id": 1,
+        "title": "Big Buck Bunny",
+        "type": "movie",
+        "label": "Animation, Comedy, Family",
+        "sublabel": "Short Film",
+        "imdb": "tt1254207",
+        "downloadas": "big-buck-bunny.mp4",
+        "comment": true,
+        "playas": "video",
+        "description": "Follow a day of the life of Big Buck Bunny when he meets three bullying rodents: Frank, Rinky, and Gamera. The rodents amuse themselves by harassing helpless creatures by throwing fruits, nuts and rocks at them. After the deaths of two of Bunny's favorite butterflies, and an offensive attack on Bunny himself, Bunny sets aside his gentle nature and orchestrates a complex plan for revenge.",
+        "classification": "G",
+        "year": "2008",
+        "duration": "8:00",
+        "rating": 6.5,
+        "views": 15000,
+        "created_at": "2024-01-01",
+        "image": "",
+        "cover": "",
+        "genres": [
+          { "id": 6, "title": "Animation" },
+          { "id": 35, "title": "Comedy" },
+          { "id": 10751, "title": "Family" }
+        ],
+        "sources": [
+          {
+            "id": 1,
+            "type": "video",
+            "title": "Big Buck Bunny 1080p",
+            "quality": "1080p",
+            "size": "264MB",
+            "kind": "both",
+            "premium": "false",
+            "external": false,
+            "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+          },
+          {
+            "id": 2,
+            "type": "video",
+            "title": "Big Buck Bunny 720p",
+            "quality": "720p",
+            "size": "128MB",
+            "kind": "both",
+            "premium": "false",
+            "external": false,
+            "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+          },
+          {
+            "id": 3,
+            "type": "video",
+            "title": "Big Buck Bunny 480p",
+            "quality": "480p",
+            "size": "64MB",
+            "kind": "both",
+            "premium": "false",
+            "external": false,
+            "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+          }
+        ],
+        "trailer": {
+          "id": 4,
+          "type": "video",
+          "title": "Big Buck Bunny Trailer",
+          "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        },
+        "actors": [
+          // No cast data from TMDB, so leave blank or as-is
+        ],
+        "subtitles": [
+          {
+            "id": 1,
+            "title": "English",
+            "language": "en",
+            "url": "https://example.com/subtitles/big-buck-bunny-en.vtt"
+          },
+          {
+            "id": 2,
+            "title": "Spanish",
+            "language": "es",
+            "url": "https://example.com/subtitles/big-buck-bunny-es.vtt"
+          }
+        ],
+        "comments": [
+          {
+            "id": 1,
+            "user": "John Doe",
+            "comment": "Amazing animation! Love this movie.",
+            "created_at": "2024-01-15T10:30:00Z"
+          },
+          {
+            "id": 2,
+            "user": "Jane Smith",
+            "comment": "Great for kids and adults alike!",
+            "created_at": "2024-01-14T15:45:00Z"
+          }
+        ],
+        "views": 15000,
+        "downloads": 5000,
+        "shares": 1200
+      }
+    ],
+    "channels": [],
+    "actors": [
+      {
+        "id": 1,
+        "name": "Tom Hanks",
+        "type": "actor",
+        "role": "Lead Actor",
+        "image": "https://example.com/tom-hanks.jpg",
+        "born": "1956-07-09",
+        "height": "6'0\"",
+        "bio": "American actor and filmmaker",
+        "movies": [
+          {
+            "id": 1,
+            "title": "Big Buck Bunny",
+            "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
+            "year": "2008"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Emma Watson",
+        "type": "actress",
+        "role": "Lead Actress",
+        "image": "https://example.com/emma-watson.jpg",
+        "born": "1990-04-15",
+        "height": "5'5\"",
+        "bio": "English actress and activist",
+        "movies": [
+          {
+            "id": 2,
+            "title": "Sample TV Series",
+            "image": "https://example.com/sample-series.jpg",
+            "year": "2023"
+          }
+        ]
+      }
+    ],
+    "genres": [
+      {
+        "id": 1,
+        "title": "Action",
+        "posters": []
+      },
+      {
+        "id": 2,
+        "title": "Comedy",
+        "posters": []
+      },
+      {
+        "id": 3,
+        "title": "Drama",
+        "posters": [
+          {
+            "id": 2,
+            "title": "Sample TV Series",
+            "image": "https://example.com/sample-series.jpg"
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Horror",
+        "posters": []
+      },
+      {
+        "id": 5,
+        "title": "Sci-Fi",
+        "posters": []
+      },
+      {
+        "id": 6,
+        "title": "Animation",
+        "posters": [
+          {
+            "id": 1,
+            "title": "Big Buck Bunny",
+            "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
+          }
+        ]
+      }
+    ]
+  },
+  "movies": [
+    {
+      "id": 1,
+      "title": "Big Buck Bunny",
+      "type": "movie",
+      "label": "Animation, Comedy, Family",
+      "sublabel": "Short Film",
+      "imdb": "tt1254207",
+      "downloadas": "big-buck-bunny.mp4",
+      "comment": true,
+      "playas": "video",
+      "description": "Follow a day of the life of Big Buck Bunny when he meets three bullying rodents: Frank, Rinky, and Gamera. The rodents amuse themselves by harassing helpless creatures by throwing fruits, nuts and rocks at them. After the deaths of two of Bunny's favorite butterflies, and an offensive attack on Bunny himself, Bunny sets aside his gentle nature and orchestrates a complex plan for revenge.",
+      "classification": "G",
+      "year": "2008",
+      "duration": "8:00",
+      "rating": 6.5,
+      "image": "",
+      "cover": "",
+      "genres": [
+        { "id": 6, "title": "Animation" },
+        { "id": 35, "title": "Comedy" },
+        { "id": 10751, "title": "Family" }
+      ],
+      "sources": [
+        {
+          "id": 1,
+          "type": "video",
+          "title": "Big Buck Bunny 1080p",
+          "quality": "1080p",
+          "size": "264MB",
+          "kind": "both",
+          "premium": "false",
+          "external": false,
+          "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        },
+        {
+          "id": 2,
+          "type": "video",
+          "title": "Big Buck Bunny 720p",
+          "quality": "720p",
+          "size": "128MB",
+          "kind": "both",
+          "premium": "false",
+          "external": false,
+          "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        },
+        {
+          "id": 3,
+          "type": "video",
+          "title": "Big Buck Bunny 480p",
+          "quality": "480p",
+          "size": "64MB",
+          "kind": "both",
+          "premium": "false",
+          "external": false,
+          "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        }
+      ],
+      "trailer": {
+        "id": 4,
+        "type": "video",
+        "title": "Big Buck Bunny Trailer",
+        "url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+      },
+      "actors": [
+        // No cast data from TMDB, so leave blank or as-is
+      ],
+      "subtitles": [
+        {
+          "id": 1,
+          "title": "English",
+          "language": "en",
+          "url": "https://example.com/subtitles/big-buck-bunny-en.vtt"
+        },
+        {
+          "id": 2,
+          "title": "Spanish",
+          "language": "es",
+          "url": "https://example.com/subtitles/big-buck-bunny-es.vtt"
+        }
+      ],
+      "comments": [
+        {
+          "id": 1,
+          "user": "John Doe",
+          "comment": "Amazing animation! Love this movie.",
+          "created_at": "2024-01-15T10:30:00Z"
+        },
+        {
+          "id": 2,
+          "user": "Jane Smith",
+          "comment": "Great for kids and adults alike!",
+          "created_at": "2024-01-14T15:45:00Z"
+        }
+      ],
+      "views": 15000,
+      "downloads": 5000,
+      "shares": 1200
+    },
+    {
+      "id": 2,
+      "title": "Sample TV Series",
+      "type": "series",
+      "label": "Drama",
+      "sublabel": "2 Seasons",
+      "imdb": "",
+      "downloadas": "sample-series",
+      "comment": true,
+      "playas": "video",
+      "description": "[TMDB AUTO-DETECTED] Example: This would be filled with TMDB overview if a real series title was used.",
+      "classification": "TV-14",
+      "year": "2023",
+      "duration": "45:00",
+      "rating": 8.2,
+      "views": 8000,
+      "created_at": "2024-01-02",
+      "image": "",
+      "cover": "",
+      "genres": [
+        { "id": 3, "title": "Drama" }
+      ],
+      "sources": [],
+      "trailer": null,
+      "actors": [
+        // Example: would be filled with TMDB actors if a real series title was used
+      ],
+      "subtitles": [],
+      "comments": [
+        {
+          "id": 1,
+          "user": "Series Fan",
+          "comment": "Amazing series! Can't wait for season 2.",
+          "created_at": "2024-01-15T12:00:00Z"
+        }
+      ],
+      "views": 8000,
+      "downloads": 2000,
+      "shares": 500,
+      "seasons": [
+        {
+          "id": 1,
+          "title": "Season 1",
+          "episodes": [
+            {
+              "id": 1,
+              "title": "Episode 1",
+              "episode_number": 1,
+              "image": "",
+              "duration": "45:00",
+              "sources": [
+                {
+                  "id": 1,
+                  "type": "embed",
+                  "title": "Vidsrc 1080p",
+                  "quality": "1080p",
+                  "url": "https://vidsrc.net/embed/series/99133/1/1"
+                }
+              ],
+              "subtitles": [],
+              "views": 5000,
+              "downloads": 1200
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "Season 2",
+          "episodes": [
+            {
+              "id": 2,
+              "title": "Episode 1",
+              "episode_number": 1,
+              "image": "",
+              "duration": "45:00",
+              "sources": [
+                {
+                  "id": 2,
+                  "type": "embed",
+                  "title": "Vidsrc 1080p",
+                  "quality": "1080p",
+                  "url": "https://vidsrc.net/embed/series/99133/2/1"
+                }
+              ],
+              "subtitles": [],
+              "views": 3000,
+              "downloads": 800
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "channels": [
+    {
+      "id": 1,
+      "title": "AZ2",
+      "label": "Entertainment",
+      "sublabel": "Philippines",
+      "description": "AZ2",
+      "website": "https://example-news.com",
+      "classification": "News",
+      "views": 25000,
+      "shares": 800,
+      "rating": 7.8,
+      "comment": true,
+      "image": "https://i.imgur.com/1zsdloF.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 6,
+          "type": "live",
+          "title": "720p",
+          "quality": "720p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_5.m3u8"
+        },
+        {
+          "id": 7,
+          "type": "live",
+          "title": "480p",
+          "quality": "480p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_4.m3u8"
+        },
+        {
+          "id": 8,
+          "type": "live",
+          "title": "360p",
+          "quality": "360p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_3.m3u8"
+        },
+        {
+          "id": 9,
+          "type": "live",
+          "title": "240p",
+          "quality": "240p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_2.m3u8"
+        },
+        {
+          "id": 10,
+          "type": "live",
+          "title": "144p",
+          "quality": "144p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_1.m3u8"
+        }
+      ],
+      "categories": [
+        {
+          "id": 3,
+          "title": "Entertainment"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 2,
+      "title": "Cine Mo!",
+      "label": "Movies",
+      "sublabel": "PH",
+      "description": "Cine Mo! is a Filipino pay television channel owned by ABS-CBN.",
+      "website": "https://example-news.com",
+      "classification": "Movies",
+      "views": 0,
+      "shares": 0,
+      "rating": 0,
+      "comment": true,
+      "image": "https://i.imgur.com/KUwrSOH.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 11,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://d1bail49udbz1k.cloudfront.net/out/v1/78e282e04f0944f3ad0aa1db7a1be645/index.m3u8"
+        }
+      ],
+      "categories": [
+        {
+          "id": 5,
+          "title": "Movies"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 3,
+      "title": "Kapamilya Channel",
+      "label": "General",
+      "sublabel": "PH",
+      "description": "",
+      "website": "https://example-news.com",
+      "classification": "General",
+      "views": 0,
+      "shares": 0,
+      "rating": 8,
+      "comment": true,
+      "image": "https://i.imgur.com/Dcys2TG.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 12,
+          "type": "live",
+          "title": "Live",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://live-faws.akamaized.net/out/v1/df7b60b4411f4270ab431913de807bf4/index.m3u8"
+        }
+      ],
+      "categories": [
+        {
+          "id": 6,
+          "title": "General"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 4,
+      "title": "Sample News Channel",
+      "label": "News",
+      "sublabel": "24/7 News",
+      "description": "24/7 news coverage from around the world",
+      "website": "https://example-news.com",
+      "classification": "News",
+      "views": 25000,
+      "shares": 800,
+      "rating": 7.8,
+      "comment": true,
+      "image": "https://example.com/news-channel.jpg",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 6,
+          "type": "live",
+          "title": "Live Stream",
+          "quality": "1080p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+        }
+      ],
+      "categories": [
+        {
+          "id": 1,
+          "title": "News"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "USA"
+        }
+      ],
+      "comments": [
+        {
+          "id": 1,
+          "user": "News Viewer",
+          "comment": "Great coverage!",
+          "created_at": "2024-01-15T09:15:00Z"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Sample Sports Channel",
+      "label": "Sports",
+      "sublabel": "Live Sports",
+      "description": "Live sports coverage and highlights",
+      "website": "https://example-sports.com",
+      "classification": "Sports",
+      "views": 18000,
+      "shares": 600,
+      "rating": 8.1,
+      "comment": true,
+      "image": "https://example.com/sports-channel.jpg",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 7,
+          "type": "live",
+          "title": "Live Sports Stream",
+          "quality": "720p",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+        }
+      ],
+      "categories": [
+        {
+          "id": 2,
+          "title": "Sports"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "USA"
+        }
+      ],
+      "comments": [
+        {
+          "id": 1,
+          "user": "Sports Fan",
+          "comment": "Amazing sports coverage!",
+          "created_at": "2024-01-15T11:20:00Z"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Cinemax",
+      "label": "Movies",
+      "sublabel": "US",
+      "description": "Premium movie channel featuring blockbuster films.",
+      "website": "https://example.com",
+      "classification": "Movies",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.5,
+      "comment": true,
+      "image": "https://i.imgur.com/7t4gFCB.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 601,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-01-prod.akamaized.net/out/u/cg_cinemax.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 296,
+          "title": "Movies"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 7,
+      "title": "Hits Now",
+      "label": "Music",
+      "sublabel": "US",
+      "description": "Music channel featuring the latest hits.",
+      "website": "https://example.com",
+      "classification": "Music",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.3,
+      "comment": true,
+      "image": "https://i.imgur.com/S3pNx8G.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 701,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-09-prod.akamaized.net/out/u/cg_hitsnow.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 474,
+          "title": "Music"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 8,
+      "title": "Hits",
+      "label": "Music",
+      "sublabel": "US",
+      "description": "Music channel playing popular hits across decades.",
+      "website": "https://example.com",
+      "classification": "Music",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.2,
+      "comment": true,
+      "image": "https://i.imgur.com/jghDgUJ.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 801,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-04-prod.akamaized.net/out/u/hits_hd1.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 474,
+          "title": "Music"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 9,
+      "title": "Hits Movies",
+      "label": "Movies",
+      "sublabel": "US",
+      "description": "Movie channel featuring popular films.",
+      "website": "https://example.com",
+      "classification": "Movies",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.4,
+      "comment": true,
+      "image": "https://i.imgur.com/zzdj40q.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 901,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-12-prod.akamaized.net/out/u/dr_hitsmovies.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 296,
+          "title": "Movies"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 10,
+      "title": "AXN",
+      "label": "Entertainment",
+      "sublabel": "US",
+      "description": "Action and adventure TV series and movies.",
+      "website": "https://example.com",
+      "classification": "Entertainment",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.5,
+      "comment": true,
+      "image": "https://i.imgur.com/Dj6tVaG.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1001,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-06-prod.akamaized.net/out/u/cg_axn_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 414,
+          "title": "Entertainment"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 11,
+      "title": "Warner TV",
+      "label": "Entertainment",
+      "sublabel": "US",
+      "description": "Warner Bros. entertainment channel featuring series and movies.",
+      "website": "https://example.com",
+      "classification": "Entertainment",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.6,
+      "comment": true,
+      "image": "https://i.imgur.com/vGEL2Ne.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1101,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-11-prod.akamaized.net/out/u/dr_warnertvhd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 414,
+          "title": "Entertainment"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 12,
+      "title": "Thrill",
+      "label": "Entertainment",
+      "sublabel": "US",
+      "description": "Channel dedicated to thriller and suspense content.",
+      "website": "https://example.com",
+      "classification": "Entertainment",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.3,
+      "comment": true,
+      "image": "https://i.imgur.com/Szf7VBM.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1201,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-06-prod.akamaized.net/out/u/cg_thrill_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 414,
+          "title": "Entertainment"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 13,
+      "title": "Lotus Macau",
+      "label": "Entertainment",
+      "sublabel": "MO",
+      "description": "Macau-based entertainment channel.",
+      "website": "https://example.com",
+      "classification": "Entertainment",
+      "views": 0,
+      "shares": 0,
+      "rating": 3.9,
+      "comment": true,
+      "image": "https://i.imgur.com/sKfzEuf.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1301,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/lotusmacau_prd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 414,
+          "title": "Entertainment"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "MO"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 14,
+      "title": "IBC13",
+      "label": "General",
+      "sublabel": "PH",
+      "description": "Philippine free-to-air television network.",
+      "website": "https://example.com",
+      "classification": "General",
+      "views": 0,
+      "shares": 0,
+      "rating": 3.8,
+      "comment": true,
+      "image": "https://i.imgur.com/Org4yTu.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1401,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/ibc13_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 959,
+          "title": "General"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 15,
+      "title": "PTV4",
+      "label": "News",
+      "sublabel": "PH",
+      "description": "Philippine government-owned news and public affairs channel.",
+      "website": "https://example.com",
+      "classification": "News",
+      "views": 0,
+      "shares": 0,
+      "rating": 3.7,
+      "comment": true,
+      "image": "https://i.imgur.com/Ktl7qZt.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1501,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/cg_ptv4_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 318,
+          "title": "News"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 16,
+      "title": "DepEd Channel",
+      "label": "Education",
+      "sublabel": "PH",
+      "description": "Educational channel by the Philippine Department of Education.",
+      "website": "https://example.com",
+      "classification": "Education",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.0,
+      "comment": true,
+      "image": "https://i.imgur.com/TyFFBWn.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1601,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/depedch_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 176,
+          "title": "Education"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 17,
+      "title": "Knowledge Channel",
+      "label": "Education",
+      "sublabel": "PH",
+      "description": "Educational channel for students and teachers.",
+      "website": "https://example.com",
+      "classification": "Education",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.2,
+      "comment": true,
+      "image": "https://i.imgur.com/UIqEr2y.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1701,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-13-prod.akamaized.net/out/u/dr_knowledgechannel.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 176,
+          "title": "Education"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 18,
+      "title": "TVN",
+      "label": "Entertainment",
+      "sublabel": "KR",
+      "description": "Korean entertainment channel featuring dramas and variety shows.",
+      "website": "https://example.com",
+      "classification": "Entertainment",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.5,
+      "comment": true,
+      "image": "https://i.imgur.com/gmM3ncL.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1801,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-09-prod.akamaized.net/out/u/cg_tvnpre.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 414,
+          "title": "Entertainment"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "KR"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 19,
+      "title": "NBA TV Philippines",
+      "label": "Sports",
+      "sublabel": "PH",
+      "description": "Philippine feed of NBA TV, covering basketball games and analysis.",
+      "website": "https://example.com",
+      "classification": "Sports",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.7,
+      "comment": true,
+      "image": "https://i.imgur.com/sG7zuX0.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 1901,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/pl_nba.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 115,
+          "title": "Sports"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 20,
+      "title": "PBA Rush",
+      "label": "Sports",
+      "sublabel": "PH",
+      "description": "Channel dedicated to Philippine Basketball Association (PBA) games.",
+      "website": "https://example.com",
+      "classification": "Sports",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.4,
+      "comment": true,
+      "image": "https://i.imgur.com/J4QCDLG.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2001,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-01-prod.akamaized.net/out/u/cg_pbarush_hd1.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 115,
+          "title": "Sports"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "PH"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 21,
+      "title": "BBC Earth",
+      "label": "Documentary",
+      "sublabel": "GB",
+      "description": "Documentary channel featuring nature and science programs.",
+      "website": "https://example.com",
+      "classification": "Documentary",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.8,
+      "comment": true,
+      "image": "https://i.imgur.com/TE9MEV1.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2101,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-03-prod.akamaized.net/out/u/cg_bbcearth_hd1.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 64,
+          "title": "Documentary"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "GB"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 22,
+      "title": "History",
+      "label": "Documentary",
+      "sublabel": "US",
+      "description": "Documentary channel featuring historical events and series.",
+      "website": "https://example.com",
+      "classification": "Documentary",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.5,
+      "comment": true,
+      "image": "https://i.imgur.com/BkoC446.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2201,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-11-prod.akamaized.net/out/u/dr_historyhd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 64,
+          "title": "Documentary"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 23,
+      "title": "Animal Planet",
+      "label": "Documentary",
+      "sublabel": "US",
+      "description": "Documentary channel focused on animals and wildlife.",
+      "website": "https://example.com",
+      "classification": "Documentary",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.4,
+      "comment": true,
+      "image": "https://i.imgur.com/1NcoovM.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2301,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/cg_animal_planet_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 64,
+          "title": "Documentary"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 24,
+      "title": "Fashion TV",
+      "label": "Lifestyle",
+      "sublabel": "FR",
+      "description": "Fashion and lifestyle channel showcasing runway shows and trends.",
+      "website": "https://example.com",
+      "classification": "Lifestyle",
+      "views": 0,
+      "shares": 0,
+      "rating": 3.9,
+      "comment": true,
+      "image": "https://i.imgur.com/wzjqyZE.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2401,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-11-prod.akamaized.net/out/u/dr_fashiontvhd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 51,
+          "title": "Lifestyle"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "FR"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 25,
+      "title": "Food Network",
+      "label": "Lifestyle",
+      "sublabel": "US",
+      "description": "Cooking and food-related programming.",
+      "website": "https://example.com",
+      "classification": "Lifestyle",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.3,
+      "comment": true,
+      "image": "https://i.imgur.com/EXC1yRz.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2501,
+          "type": "live",
+          "title": "HD",
+          "quality": "HD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-09-prod.akamaized.net/out/u/cg_foodnetwork_hd1.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 51,
+          "title": "Lifestyle"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    },
+    {
+      "id": 26,
+      "title": "Bloomberg",
+      "label": "News",
+      "sublabel": "US",
+      "description": "Financial news and market updates.",
+      "website": "https://example.com",
+      "classification": "News",
+      "views": 0,
+      "shares": 0,
+      "rating": 4.2,
+      "comment": true,
+      "image": "https://i.imgur.com/pl4w2NN.png",
+      "playas": "live",
+      "sources": [
+        {
+          "id": 2601,
+          "type": "live",
+          "title": "SD",
+          "quality": "SD",
+          "size": "Live",
+          "kind": "play",
+          "premium": "false",
+          "external": false,
+          "url": "https://qp-pldt-live-grp-09-prod.akamaized.net/out/u/bloomberg_sd.mpd"
+        }
+      ],
+      "categories": [
+        {
+          "id": 318,
+          "title": "News"
+        }
+      ],
+      "countries": [
+        {
+          "id": 1,
+          "title": "US"
+        }
+      ],
+      "comments": []
+    }
+  ],
+  "actors": [
+    {
+      "id": 1,
+      "name": "Tom Hanks",
+      "type": "actor",
+      "role": "Lead Actor",
+      "image": "https://example.com/tom-hanks.jpg",
+      "born": "1956-07-09",
+      "height": "6'0\"",
+      "bio": "American actor and filmmaker",
+      "movies": [
+        {
+          "id": 1,
+          "title": "Big Buck Bunny",
+          "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217",
+          "year": "2008"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Emma Watson",
+      "type": "actress",
+      "role": "Lead Actress",
+      "image": "https://example.com/emma-watson.jpg",
+      "born": "1990-04-15",
+      "height": "5'5\"",
+      "bio": "English actress and activist",
+      "movies": [
+        {
+          "id": 2,
+          "title": "Sample TV Series",
+          "image": "https://example.com/sample-series.jpg",
+          "year": "2023"
+        }
+      ]
+    }
+  ],
+  "genres": [
+    {
+      "id": 1,
+      "title": "Action",
+      "posters": []
+    },
+    {
+      "id": 2,
+      "title": "Comedy",
+      "posters": []
+    },
+    {
+      "id": 3,
+      "title": "Drama",
+      "posters": [
+        {
+          "id": 2,
+          "title": "Sample TV Series",
+          "image": "https://example.com/sample-series.jpg"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Horror",
+      "posters": []
+    },
+    {
+      "id": 5,
+      "title": "Sci-Fi",
+      "posters": []
+    },
+    {
+      "id": 6,
+      "title": "Animation",
+      "posters": [
+        {
+          "id": 1,
+          "title": "Big Buck Bunny",
+          "image": "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
+        }
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "id": 1,
+      "title": "News"
+    },
+    {
+      "id": 2,
+      "title": "Sports"
+    },
+    {
+      "id": 3,
+      "title": "Entertainment"
+    },
+    {
+      "id": 4,
+      "title": "Documentary"
+    }
+  ],
+  "countries": [
+    {
+      "id": 1,
+      "title": "USA"
+    },
+    {
+      "id": 2,
+      "title": "UK"
+    },
+    {
+      "id": 3,
+      "title": "France"
+    },
+    {
+      "id": 4,
+      "title": "Germany"
+    }
+  ],
+  "subscription_plans": [],
+  "subscription_config": {
+    "enabled": false,
+    "monthly_billing_enabled": false,
+    "free_trial_days": 0,
+    "grace_period_days": 0,
+    "auto_renewal_enabled": false,
+    "payment_methods": [],
+    "currency_default": "USD",
+    "subscription_required_for": []
+  },
+  "video_sources": {
+    "big_buck_bunny": {
+      "title": "Big Buck Bunny",
+      "description": "Famous open-source animation by Blender Foundation",
+      "urls": {
+        "1080p": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+        "720p": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+        "480p": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+      },
+      "duration": "10:00",
+      "size": "264MB (1080p)",
+      "license": "Creative Commons Attribution 3.0"
+    },
+    "elephants_dream": {
+      "title": "Elephants Dream",
+      "description": "The world's first open movie",
+      "urls": {
+        "1080p": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4"
+      },
+      "duration": "11:00",
+      "size": "128MB",
+      "license": "Creative Commons Attribution 2.5"
+    },
+    "live_streams": {
+      "test_hls": {
+        "title": "Test HLS Stream",
+        "description": "Sample HLS live stream for testing",
+        "url": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8",
+        "quality": "1080p",
+        "type": "live"
+      }
+    }
+  },
+  "ads_config": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Integrate TMDB auto-detection for movie and TV series metadata, excluding images and preserving/adding vidsrc.net sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-0047992f-c7c4-4131-aa54-e0216977d1d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0047992f-c7c4-4131-aa54-e0216977d1d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>