### PR TITLE
Fix series season and episode display bug

### DIFF
--- a/CineMax/app/src/main/java/my/cinemax/app/free/entity/Episode.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/entity/Episode.java
@@ -1,11 +1,14 @@
 package my.cinemax.app.free.entity;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
-public class Episode {
+public class Episode implements Parcelable {
 
     @SerializedName("id")
     @Expose
@@ -36,6 +39,58 @@ public class Episode {
     @SerializedName("sources")
     @Expose
     private List<Source> sources = null;
+
+    public Episode() {
+    }
+
+    protected Episode(Parcel in) {
+        if (in.readByte() == 0) {
+            id = null;
+        } else {
+            id = in.readInt();
+        }
+        title = in.readString();
+        description = in.readString();
+        downloadas = in.readString();
+        playas = in.readString();
+        duration = in.readString();
+        image = in.readString();
+        sources = in.createTypedArrayList(Source.CREATOR);
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        if (id == null) {
+            dest.writeByte((byte) 0);
+        } else {
+            dest.writeByte((byte) 1);
+            dest.writeInt(id);
+        }
+        dest.writeString(title);
+        dest.writeString(description);
+        dest.writeString(downloadas);
+        dest.writeString(playas);
+        dest.writeString(duration);
+        dest.writeString(image);
+        dest.writeTypedList(sources);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<Episode> CREATOR = new Creator<Episode>() {
+        @Override
+        public Episode createFromParcel(Parcel in) {
+            return new Episode(in);
+        }
+
+        @Override
+        public Episode[] newArray(int size) {
+            return new Episode[size];
+        }
+    };
 
     public Integer getId() {
         return id;

--- a/CineMax/app/src/main/java/my/cinemax/app/free/entity/Poster.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/entity/Poster.java
@@ -100,6 +100,10 @@ public class Poster implements Parcelable {
     @Expose
     private Source trailer ;
 
+    @SerializedName("seasons")
+    @Expose
+    private List<Season> seasons = new ArrayList<>();
+
     private int typeView = 1;
 
     public Poster() {
@@ -142,6 +146,7 @@ public class Poster implements Parcelable {
         createdAt = in.readString();
         sources = in.createTypedArrayList(Source.CREATOR);
         trailer = in.readParcelable(Source.class.getClassLoader());
+        seasons = in.createTypedArrayList(Season.CREATOR);
         typeView = in.readInt();
     }
 
@@ -184,6 +189,7 @@ public class Poster implements Parcelable {
         dest.writeString(createdAt);
         dest.writeTypedList(sources);
         dest.writeParcelable(trailer, flags);
+        dest.writeTypedList(seasons);
         dest.writeInt(typeView);
     }
 
@@ -391,6 +397,14 @@ public class Poster implements Parcelable {
 
     public String getSublabel() {
         return sublabel;
+    }
+
+    public List<Season> getSeasons() {
+        return seasons;
+    }
+
+    public void setSeasons(List<Season> seasons) {
+        this.seasons = seasons;
     }
 }
 

--- a/CineMax/app/src/main/java/my/cinemax/app/free/entity/Season.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/entity/Season.java
@@ -1,11 +1,14 @@
 package my.cinemax.app.free.entity;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
-public class Season {
+public class Season implements Parcelable {
     @SerializedName("id")
     @Expose
     private Integer id;
@@ -15,6 +18,48 @@ public class Season {
     @SerializedName("episodes")
     @Expose
     private List<Episode> episodes = null;
+
+    public Season() {
+    }
+
+    protected Season(Parcel in) {
+        if (in.readByte() == 0) {
+            id = null;
+        } else {
+            id = in.readInt();
+        }
+        title = in.readString();
+        episodes = in.createTypedArrayList(Episode.CREATOR);
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        if (id == null) {
+            dest.writeByte((byte) 0);
+        } else {
+            dest.writeByte((byte) 1);
+            dest.writeInt(id);
+        }
+        dest.writeString(title);
+        dest.writeTypedList(episodes);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<Season> CREATOR = new Creator<Season>() {
+        @Override
+        public Season createFromParcel(Parcel in) {
+            return new Season(in);
+        }
+
+        @Override
+        public Season[] newArray(int size) {
+            return new Season[size];
+        }
+    };
 
     public Integer getId() {
         return id;

--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/SerieActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/SerieActivity.java
@@ -424,63 +424,86 @@ public class SerieActivity extends AppCompatActivity implements PlaylistDownload
         }
     }
     private void getSeasons() {
-
-        Retrofit retrofit = apiClient.getClient();
-        apiRest service = retrofit.create(apiRest.class);
-
-        Call<List<Season>> call = service.getSeasonsBySerie(poster.getId());
-        call.enqueue(new Callback<List<Season>>() {
+        // Use JSON API instead of old REST API
+        apiClient.getJsonApiData(new retrofit2.Callback<my.cinemax.app.free.entity.JsonApiResponse>() {
             @Override
-            public void onResponse(Call<List<Season>> call, Response<List<Season>> response) {
-                if (response.isSuccessful()){
-                    if (response.body().size()>0) {
-                        seasonArrayList.clear();
-                        final String[] countryCodes = new String[response.body().size()];
-
-                        for (int i = 0; i < response.body().size(); i++) {
-                            countryCodes[i] = response.body().get(i).getTitle();
-                            seasonArrayList.add(response.body().get(i));
+            public void onResponse(Call<my.cinemax.app.free.entity.JsonApiResponse> call, retrofit2.Response<my.cinemax.app.free.entity.JsonApiResponse> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    my.cinemax.app.free.entity.JsonApiResponse apiResponse = response.body();
+                    
+                    if (apiResponse.getMovies() != null) {
+                        // Find the specific series by ID
+                        Poster targetSeries = null;
+                        for (Poster movie : apiResponse.getMovies()) {
+                            if (movie.getId() != null && movie.getId().equals(poster.getId())) {
+                                targetSeries = movie;
+                                break;
+                            }
                         }
-                        ArrayAdapter<String> filtresAdapter = new ArrayAdapter<String>(SerieActivity.this,
-                                R.layout.spinner_layout_season,R.id.textView,countryCodes);
-                        filtresAdapter.setDropDownViewResource(R.layout.simple_spinner_dropdown_season_item);
-                        spinner_activity_serie_season_list.setAdapter(filtresAdapter);
+                        
+                        if (targetSeries != null && targetSeries.getSeasons() != null && targetSeries.getSeasons().size() > 0) {
+                            seasonArrayList.clear();
+                            final String[] countryCodes = new String[targetSeries.getSeasons().size()];
 
-                        linear_layout_activity_serie_seasons.setVisibility(View.VISIBLE);
-                    }else{
+                            for (int i = 0; i < targetSeries.getSeasons().size(); i++) {
+                                countryCodes[i] = targetSeries.getSeasons().get(i).getTitle();
+                                seasonArrayList.add(targetSeries.getSeasons().get(i));
+                            }
+                            ArrayAdapter<String> filtresAdapter = new ArrayAdapter<String>(SerieActivity.this,
+                                    R.layout.spinner_layout_season,R.id.textView,countryCodes);
+                            filtresAdapter.setDropDownViewResource(R.layout.simple_spinner_dropdown_season_item);
+                            spinner_activity_serie_season_list.setAdapter(filtresAdapter);
+
+                            linear_layout_activity_serie_seasons.setVisibility(View.VISIBLE);
+                        } else {
+                            linear_layout_activity_serie_seasons.setVisibility(View.GONE);
+                        }
+                    } else {
                         linear_layout_activity_serie_seasons.setVisibility(View.GONE);
                     }
-                }else{
-                    linear_layout_activity_serie_seasons.setVisibility(View.VISIBLE);
+                } else {
+                    linear_layout_activity_serie_seasons.setVisibility(View.GONE);
                 }
             }
+            
             @Override
-            public void onFailure(Call<List<Season>> call, Throwable t) {
+            public void onFailure(Call<my.cinemax.app.free.entity.JsonApiResponse> call, Throwable t) {
                 linear_layout_activity_serie_seasons.setVisibility(View.GONE);
-
             }
         });
     }
     private void getPosterCastings() {
-        Retrofit retrofit = apiClient.getClient();
-        apiRest service = retrofit.create(apiRest.class);
-        Call<List<Actor>> call = service.getRolesByPoster(poster.getId());
-        call.enqueue(new Callback<List<Actor>>() {
+        // Use JSON API instead of old REST API
+        apiClient.getJsonApiData(new retrofit2.Callback<my.cinemax.app.free.entity.JsonApiResponse>() {
             @Override
-            public void onResponse(Call<List<Actor>> call, Response<List<Actor>> response) {
-                if (response.isSuccessful()){
-                    if (response.body().size()>0) {
-                        linearLayoutManagerCast = new LinearLayoutManager(getApplicationContext(), LinearLayoutManager.HORIZONTAL, false);
-                        actorAdapter = new ActorAdapter(response.body(), SerieActivity.this);
-                        recycle_view_activity_activity_serie_cast.setHasFixedSize(true);
-                        recycle_view_activity_activity_serie_cast.setAdapter(actorAdapter);
-                        recycle_view_activity_activity_serie_cast.setLayoutManager(linearLayoutManagerCast);
-                        linear_layout_activity_serie_cast.setVisibility(View.VISIBLE);
+            public void onResponse(Call<my.cinemax.app.free.entity.JsonApiResponse> call, retrofit2.Response<my.cinemax.app.free.entity.JsonApiResponse> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    my.cinemax.app.free.entity.JsonApiResponse apiResponse = response.body();
+                    
+                    if (apiResponse.getMovies() != null) {
+                        // Find the specific series by ID
+                        Poster targetSeries = null;
+                        for (Poster movie : apiResponse.getMovies()) {
+                            if (movie.getId() != null && movie.getId().equals(poster.getId())) {
+                                targetSeries = movie;
+                                break;
+                            }
+                        }
+                        
+                        if (targetSeries != null && targetSeries.getActors() != null && targetSeries.getActors().size() > 0) {
+                            linearLayoutManagerCast = new LinearLayoutManager(getApplicationContext(), LinearLayoutManager.HORIZONTAL, false);
+                            actorAdapter = new ActorAdapter(targetSeries.getActors(), SerieActivity.this);
+                            recycle_view_activity_activity_serie_cast.setHasFixedSize(true);
+                            recycle_view_activity_activity_serie_cast.setAdapter(actorAdapter);
+                            recycle_view_activity_activity_serie_cast.setLayoutManager(linearLayoutManagerCast);
+                            linear_layout_activity_serie_cast.setVisibility(View.VISIBLE);
+                        }
                     }
                 }
             }
+            
             @Override
-            public void onFailure(Call<List<Actor>> call, Throwable t) {
+            public void onFailure(Call<my.cinemax.app.free.entity.JsonApiResponse> call, Throwable t) {
             }
         });
     }


### PR DESCRIPTION
Fix series functionality to display seasons and episodes correctly.

The `SerieActivity` was attempting to fetch season and episode data using deprecated REST API endpoints which are no longer supported by the new JSON API. Additionally, the `Poster` entity lacked a `seasons` field, and the `Season` and `Episode` entities were not `Parcelable`, preventing proper data transfer and display. This PR updates the data fetching logic to use the JSON API and ensures the necessary entity classes are correctly structured.

---
<a href="https://cursor.com/background-agent?bcId=bc-89ec4e8e-3bd0-47e6-bc5b-6fce6a8ec421">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89ec4e8e-3bd0-47e6-bc5b-6fce6a8ec421">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>