### PR TITLE
Fix cine max episode source detection

### DIFF
--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/ChannelActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/ChannelActivity.java
@@ -302,9 +302,16 @@ public class ChannelActivity extends AppCompatActivity {
         if (channel != null && channel.getSources() != null) {
             for (int i = 0; i < channel.getSources().size(); i++) {
                 Source source = channel.getSources().get(i);
-                if (source != null && source.getKind() != null && 
-                    (source.getKind().equals("both") || source.getKind().equals("play"))) {
-                    playSources.add(source);
+                if (source != null) {
+                    // Handle sources with kind field
+                    if (source.getKind() != null && 
+                        (source.getKind().equals("both") || source.getKind().equals("play"))) {
+                        playSources.add(source);
+                    }
+                    // Handle sources without kind field - treat as playable by default
+                    else if (source.getKind() == null && source.getUrl() != null && !source.getUrl().isEmpty()) {
+                        playSources.add(source);
+                    }
                 }
             }
         }

--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/MovieActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/MovieActivity.java
@@ -361,9 +361,16 @@ public class MovieActivity extends AppCompatActivity {
         if (poster != null && poster.getSources() != null) {
             for (int i = 0; i < poster.getSources().size(); i++) {
                 Source source = poster.getSources().get(i);
-                if (source != null && source.getKind() != null && 
-                    (source.getKind().equals("both") || source.getKind().equals("play"))) {
-                    playSources.add(source);
+                if (source != null) {
+                    // Handle sources with kind field (movies)
+                    if (source.getKind() != null && 
+                        (source.getKind().equals("both") || source.getKind().equals("play"))) {
+                        playSources.add(source);
+                    }
+                    // Handle sources without kind field - treat as playable by default
+                    else if (source.getKind() == null && source.getUrl() != null && !source.getUrl().isEmpty()) {
+                        playSources.add(source);
+                    }
                 }
             }
         }
@@ -372,10 +379,19 @@ public class MovieActivity extends AppCompatActivity {
         if (poster != null && poster.getSources() != null) {
             for (int i = 0; i < poster.getSources().size(); i++) {
                 Source source = poster.getSources().get(i);
-                if (source != null && source.getKind() != null && source.getType() != null &&
-                    (source.getKind().equals("both") || source.getKind().equals("download"))) {
-                    if (!source.getType().equals("youtube") && !source.getType().equals("embed")) {
-                        downloadableList.add(source);
+                if (source != null) {
+                    // Handle sources with kind field (movies)
+                    if (source.getKind() != null && source.getType() != null &&
+                        (source.getKind().equals("both") || source.getKind().equals("download"))) {
+                        if (!source.getType().equals("youtube") && !source.getType().equals("embed")) {
+                            downloadableList.add(source);
+                        }
+                    }
+                    // Handle sources without kind field - treat as downloadable by default
+                    else if (source.getKind() == null && source.getUrl() != null && !source.getUrl().isEmpty()) {
+                        if (source.getType() == null || (!source.getType().equals("youtube") && !source.getType().equals("embed"))) {
+                            downloadableList.add(source);
+                        }
                     }
                 }
             }

--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/SerieActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/SerieActivity.java
@@ -376,10 +376,19 @@ public class SerieActivity extends AppCompatActivity implements PlaylistDownload
         if (episode != null && episode.getSources() != null) {
             for (int i = 0; i < episode.getSources().size(); i++) {
                 Source source = episode.getSources().get(i);
-                if (source != null && source.getKind() != null && source.getType() != null &&
-                    (source.getKind().equals("both") || source.getKind().equals("download"))) {
-                    if (!source.getType().equals("youtube") && !source.getType().equals("embed")) {
-                        downloadableList.add(source);
+                if (source != null) {
+                    // Handle sources with kind field (movies)
+                    if (source.getKind() != null && source.getType() != null &&
+                        (source.getKind().equals("both") || source.getKind().equals("download"))) {
+                        if (!source.getType().equals("youtube") && !source.getType().equals("embed")) {
+                            downloadableList.add(source);
+                        }
+                    }
+                    // Handle sources without kind field (episodes) - treat as downloadable by default
+                    else if (source.getKind() == null && source.getUrl() != null && !source.getUrl().isEmpty()) {
+                        if (source.getType() == null || (!source.getType().equals("youtube") && !source.getType().equals("embed"))) {
+                            downloadableList.add(source);
+                        }
                     }
                 }
             }
@@ -403,9 +412,16 @@ public class SerieActivity extends AppCompatActivity implements PlaylistDownload
         if (episode != null && episode.getSources() != null) {
             for (int i = 0; i < episode.getSources().size(); i++) {
                 Source source = episode.getSources().get(i);
-                if (source != null && source.getKind() != null && 
-                    (source.getKind().equals("both") || source.getKind().equals("play"))) {
-                    playableList.add(source);
+                if (source != null) {
+                    // Handle sources with kind field (movies)
+                    if (source.getKind() != null && 
+                        (source.getKind().equals("both") || source.getKind().equals("play"))) {
+                        playableList.add(source);
+                    }
+                    // Handle sources without kind field (episodes) - treat as playable by default
+                    else if (source.getKind() == null && source.getUrl() != null && !source.getUrl().isEmpty()) {
+                        playableList.add(source);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Update source filtering logic to correctly detect episode sources missing the 'kind' field.

Episode sources in the JSON API do not include a `kind` field, unlike movie and channel sources. The previous filtering logic in `SerieActivity`, `MovieActivity`, and `ChannelActivity` required the `kind` field to be present and set to "both" or "play", causing episode sources to be incorrectly filtered out and resulting in a "no source available" message. This change modifies the logic to treat sources without a `kind` field as playable by default if they have a valid URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebbea2da-a91e-4c2a-8a81-2cb76fb92dfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebbea2da-a91e-4c2a-8a81-2cb76fb92dfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>