### PR TITLE
Enhance cine max index html with auto content generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2396,7 +2396,7 @@
                     cover: movieCoverInput.value.trim(),
                     trailer: movieTrailerInput.value.trim() ? { 
                         id: generateNewId(),
-                        type: 'video',
+                        type: 'youtube',
                         title: `${movieTitleInput.value.trim()} Trailer`,
                         url: movieTrailerInput.value.trim() 
                     } : null,
@@ -2465,10 +2465,11 @@
                                 downloads: 0,
                                 sources: [{ 
                                     id: generateNewId(),
-                                    type: 'video', 
+                                    type: 'embed',
                                     title: `${episodeTitle} 1080p`,
                                     quality: '1080p',
-                                    url: sourceUrl 
+                                    url: sourceUrl,
+                                    kind: 'play'
                                 }],
                                 subtitles: []
                             });
@@ -2493,7 +2494,7 @@
                     cover: seriesCoverInput.value.trim(),
                     trailer: seriesTrailerInput.value.trim() ? { 
                         id: generateNewId(),
-                        type: 'video',
+                        type: 'youtube',
                         title: `${seriesTitleInput.value.trim()} Trailer`,
                         url: seriesTrailerInput.value.trim() 
                     } : null,
@@ -3046,21 +3047,34 @@
                     cover: movieData.backdrop_path ? `https://image.tmdb.org/t/p/original${movieData.backdrop_path}` : '',
                     trailer: trailer ? {
                         id: generateNewId(),
-                        type: 'video',
+                        type: 'youtube',
                         title: `${movieData.title} Trailer`,
                         url: `https://www.youtube.com/watch?v=${trailer.key}`
                     } : null,
-                    sources: [{
-                        id: generateNewId(),
-                        type: 'video',
-                        title: 'vidsrc.net 1080p',
-                        quality: '1080p',
-                        size: '0MB',
-                        kind: 'both',
-                        premium: 'false',
-                        external: false,
-                        url: `https://vidsrc.net/embed/movie/${movieData.id}`
-                    }],
+                    sources: [
+                        {
+                            id: generateNewId(),
+                            type: 'embed',
+                            title: 'vidsrc.net',
+                            quality: 'HD',
+                            size: '0MB',
+                            kind: 'play',
+                            premium: 'false',
+                            external: false,
+                            url: `https://vidsrc.net/embed/movie/${movieData.id}`
+                        },
+                        {
+                            id: generateNewId(),
+                            type: 'embed',
+                            title: 'VidJoy',
+                            quality: 'HD',
+                            size: '0MB',
+                            kind: 'play',
+                            premium: 'false',
+                            external: false,
+                            url: `https://vidjoy.pro/embed/${movieData.id}`
+                        }
+                    ],
                     label: 'Movie',
                     sublabel: movieData.release_date ? movieData.release_date.split('-')[0] : 'N/A',
                     imdb: movieData.vote_average ? movieData.vote_average.toString() : '0.0',
@@ -3121,7 +3135,7 @@
                     cover: seriesData.backdrop_path ? `https://image.tmdb.org/t/p/original${seriesData.backdrop_path}` : '',
                     trailer: trailer ? {
                         id: generateNewId(),
-                        type: 'video',
+                        type: 'youtube',
                         title: `${seriesData.name} Trailer`,
                         url: `https://www.youtube.com/watch?v=${trailer.key}`
                     } : null,
@@ -3214,17 +3228,31 @@
                     
                     // Auto-add vidsrc source
                     const vidsrcUrl = `https://vidsrc.net/embed/movie/${tmdbId}`;
-                    currentMovieSources = [{ 
-                        id: generateNewId(),
-                        type: 'video',
-                        title: 'vidsrc.net 1080p',
-                        quality: '1080p',
-                        size: '0MB',
-                        kind: 'both',
-                        premium: 'false',
-                        external: false,
-                        url: vidsrcUrl 
-                    }];
+                    const vidjoyUrl = `https://vidjoy.pro/embed/${tmdbId}`;
+                    currentMovieSources = [
+                        { 
+                            id: generateNewId(),
+                            type: 'embed',
+                            title: 'vidsrc.net',
+                            quality: 'HD',
+                            size: '0MB',
+                            kind: 'play',
+                            premium: 'false',
+                            external: false,
+                            url: vidsrcUrl 
+                        },
+                        {
+                            id: generateNewId(),
+                            type: 'embed',
+                            title: 'VidJoy',
+                            quality: 'HD',
+                            size: '0MB',
+                            kind: 'play',
+                            premium: 'false',
+                            external: false,
+                            url: vidjoyUrl
+                        }
+                    ];
                     renderMovieSources();
                     
                     // Auto-generate related content after TMDB fetch
@@ -3316,10 +3344,11 @@
                                     downloads: 0,
                                     sources: [{
                                         id: generateNewId(),
-                                        type: 'video',
+                                        type: 'embed',
                                         title: `Episode ${episodeNumber} 1080p`,
                                         quality: '1080p',
-                                        url: vidsrcEpisodeUrl
+                                        url: vidsrcEpisodeUrl,
+                                        kind: 'play'
                                     }],
                                     subtitles: []
                                 };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance `index.html` to correctly categorize video sources and trailers, and integrate VidJoy as an additional embed source.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR aligns the `index.html`'s content generation logic with the user's specified `type` and `kind` values for different video sources (e.g., `youtube` for trailers, `embed` for embedded content with `play` kind). It also adds `vidjoy.pro` as a secondary auto-generated embed source, improving content variety and ensuring proper playback behavior. No Java code changes were required as the existing backend handles these updated fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-aab4d743-1148-45bf-ada9-53ed49ff0cde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aab4d743-1148-45bf-ada9-53ed49ff0cde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>