### PR TITLE
Analyze and update api_gen.html

### DIFF
--- a/api_gen.html
+++ b/api_gen.html
@@ -1092,6 +1092,10 @@
             });
 
             currentData.home.featuredMovies.push(movie);
+            
+            // Ensure movie has actors and genres arrays (even if empty)
+            if (!movie.actors) movie.actors = [];
+            if (!movie.genres) movie.genres = [];
             currentData.api_info.total_movies++;
             
             saveData();
@@ -1259,6 +1263,10 @@
             });
 
             currentData.home.featuredMovies.push(series);
+            
+            // Ensure series has actors and genres arrays (even if empty)
+            if (!series.actors) series.actors = [];
+            if (!series.genres) series.genres = [];
             currentData.api_info.total_series++;
             
             saveData();
@@ -1335,8 +1343,14 @@
          function generateActorsFromContent() {
              const actorMap = new Map();
              
-             (currentData.home.featuredMovies || []).forEach(content => {
-                 if (content.actors) {
+             // Process both slides and featuredMovies to ensure all actors are captured
+             const allContent = [
+                 ...(currentData.home.slides || []).map(slide => slide.poster || slide),
+                 ...(currentData.home.featuredMovies || [])
+             ];
+             
+             allContent.forEach(content => {
+                 if (content && content.actors && Array.isArray(content.actors)) {
                      content.actors.forEach(actor => {
                          if (actor.name && !actorMap.has(actor.name)) {
                              actorMap.set(actor.name, {
@@ -1374,8 +1388,14 @@
          function generateGenresFromContent() {
              const genreMap = new Map();
              
-             (currentData.home.featuredMovies || []).forEach(content => {
-                 if (content.genres) {
+             // Process both slides and featuredMovies to ensure all genres are captured
+             const allContent = [
+                 ...(currentData.home.slides || []).map(slide => slide.poster || slide),
+                 ...(currentData.home.featuredMovies || [])
+             ];
+             
+             allContent.forEach(content => {
+                 if (content && content.genres && Array.isArray(content.genres)) {
                      content.genres.forEach(genre => {
                          const genreTitle = genre.title || genre.name;
                          if (genreTitle && !genreMap.has(genreTitle)) {
@@ -1571,6 +1591,10 @@
                 
                 currentData.home.channels.push(channel);
                 currentData.api_info.total_channels++;
+                
+                // Ensure channel has actors and genres arrays (even if empty)
+                if (!channel.actors) channel.actors = [];
+                if (!channel.genres) channel.genres = [];
             } else {
                 currentData.home.slides.push({
                     id: content.id,
@@ -1582,6 +1606,10 @@
                 });
                 
                 currentData.home.featuredMovies.push(content);
+                
+                // Ensure content has actors and genres arrays (even if empty)
+                if (!content.actors) content.actors = [];
+                if (!content.genres) content.genres = [];
                 
                 if (type === 'movie') {
                     currentData.api_info.total_movies++;
@@ -1782,9 +1810,11 @@
                  ...currentData,
                  // Add root-level movies array that includes both movies and series
                  movies: currentData.home.featuredMovies || [],
-                 // Add root-level arrays for compatibility
-                 actors: generateActorsFromContent(),
-                 genres: generateGenresFromContent()
+                 // Add root-level arrays for compatibility - ensure they're always present
+                 actors: generateActorsFromContent() || [],
+                 genres: generateGenresFromContent() || [],
+                 // Ensure channels array is present
+                 channels: currentData.channels || []
              };
              
              const dataStr = JSON.stringify(exportData, null, 2);

--- a/api_gen.html
+++ b/api_gen.html
@@ -1806,8 +1806,21 @@
 
                  function exportData() {
              // Create the complete CineMax API structure with root-level movies array
+             // Limit slides to top-rated content (highest rating first)
+             const limitedSlides = (currentData.home.slides || [])
+                 .sort((a, b) => {
+                     const ratingA = a.poster?.rating || a.rating || 0;
+                     const ratingB = b.poster?.rating || b.rating || 0;
+                     return ratingB - ratingA; // Sort by highest rating first
+                 })
+                 .slice(0, 10); // Limit to top 10 highest rated items
+             
              const exportData = {
                  ...currentData,
+                 home: {
+                     ...currentData.home,
+                     slides: limitedSlides // Use limited slides instead of all slides
+                 },
                  // Add root-level movies array that includes both movies and series
                  movies: currentData.home.featuredMovies || [],
                  // Add root-level arrays for compatibility - ensure they're always present

--- a/api_gen.html
+++ b/api_gen.html
@@ -1819,11 +1819,16 @@
                  ...currentData,
                  home: {
                      ...currentData.home,
-                     slides: limitedSlides // Use limited slides instead of all slides
+                     slides: limitedSlides, // Use limited slides instead of all slides
+                     // Add featuredMovies INSIDE home object for LoadActivity compatibility
+                     featuredMovies: currentData.home.featuredMovies || [],
+                     // Add actors and genres INSIDE home object for HomeFragment compatibility
+                     actors: generateActorsFromContent() || [],
+                     genres: generateGenresFromContent() || []
                  },
                  // Add root-level movies array that includes both movies and series
                  movies: currentData.home.featuredMovies || [],
-                 // Add root-level arrays for compatibility - ensure they're always present
+                 // Keep root-level arrays for other fragments compatibility
                  actors: generateActorsFromContent() || [],
                  genres: generateGenresFromContent() || [],
                  // Ensure channels array is present


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure generated API JSON includes global actors, genres, and channels, and proper content-level actor/genre arrays to fix missing Home Category display.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous generation logic in `api_gen.html` sometimes omitted global actor/genre arrays or didn't guarantee their presence within individual content items (movies, series, channels). This led to the CineMax app's Home Category failing to display actors and genres. This update standardizes the JSON output to match the reference API structure, ensuring all necessary data points are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-c79fc122-a674-42b8-a83a-36074b15aaeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c79fc122-a674-42b8-a83a-36074b15aaeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>