### PR TITLE
Investigate and fix video playback errors

### DIFF
--- a/CineMax/app/src/main/java/my/cinemax/app/free/entity/Source.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/entity/Source.java
@@ -43,6 +43,10 @@ public class Source implements Parcelable {
     @SerializedName("url")
     @Expose
     private String url;
+    
+    @SerializedName("serverType")
+    @Expose
+    private String serverType; // For server categorization (vidsrc_primary, vidjoy_backup, etc.)
 
 
     protected Source(Parcel in) {
@@ -60,6 +64,7 @@ public class Source implements Parcelable {
         byte tmpExternal = in.readByte();
         external = tmpExternal == 0 ? null : tmpExternal == 1;
         url = in.readString();
+        serverType = in.readString();
     }
 
     @Override
@@ -78,6 +83,7 @@ public class Source implements Parcelable {
         dest.writeString(premium);
         dest.writeByte((byte) (external == null ? 0 : external ? 1 : 2));
         dest.writeString(url);
+        dest.writeString(serverType);
     }
 
     @Override
@@ -168,5 +174,42 @@ public class Source implements Parcelable {
 
     public Boolean getExternal() {
         return external;
+    }
+    
+    public String getServerType() {
+        return serverType;
+    }
+    
+    public void setServerType(String serverType) {
+        this.serverType = serverType;
+    }
+    
+    /**
+     * Check if this source is a primary server (not a backup)
+     */
+    public boolean isPrimaryServer() {
+        return serverType != null && serverType.contains("primary");
+    }
+    
+    /**
+     * Check if this source is a backup server
+     */
+    public boolean isBackupServer() {
+        return serverType != null && serverType.contains("backup");
+    }
+    
+    /**
+     * Get server priority (lower number = higher priority)
+     */
+    public int getServerPriority() {
+        if (serverType == null) return 999; // Unknown servers get lowest priority
+        
+        if (serverType.contains("vidsrc_primary")) return 1;
+        if (serverType.contains("vidjoy_primary")) return 2;
+        if (serverType.contains("vidsrc_backup")) return 3;
+        if (serverType.contains("vidjoy_backup")) return 4;
+        if (serverType.contains("additional_backup")) return 5;
+        
+        return 999; // Default lowest priority
     }
 }

--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/EmbedActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/EmbedActivity.java
@@ -2,21 +2,34 @@ package my.cinemax.app.free.ui.activities;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.os.Handler;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import my.cinemax.app.free.R;
+import es.dmoral.toasty.Toasty;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class EmbedActivity extends AppCompatActivity {
+    private static final String TAG = "EmbedActivity";
     private WebView webView;
     private FrameLayout customViewContainer;
     private WebChromeClient.CustomViewCallback customViewCallback;
@@ -24,6 +37,16 @@ public class EmbedActivity extends AppCompatActivity {
     private myWebChromeClient mWebChromeClient;
     private myWebViewClient mWebViewClient;
     private String url;
+    private ProgressBar progressBar;
+    private TextView errorText;
+    private Handler retryHandler;
+    private int retryCount = 0;
+    private static final int MAX_RETRIES = 3;
+    private static final long RETRY_DELAY = 3000; // 3 seconds
+    
+    // Backup servers for fallback
+    private List<String> backupServers = new ArrayList<>();
+    private int currentServerIndex = 0;
 
     /**
      * Called when the activity is first created.
@@ -36,7 +59,6 @@ public class EmbedActivity extends AppCompatActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_embed);
 
-
         View decorView = getWindow().getDecorView();
         decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
@@ -45,22 +67,168 @@ public class EmbedActivity extends AppCompatActivity {
                 | View.SYSTEM_UI_FLAG_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
 
-        Bundle bundle = getIntent().getExtras() ;
-        url = bundle.getString("url");
+        Bundle bundle = getIntent().getExtras();
+        if (bundle != null) {
+            url = bundle.getString("url");
+        }
+        
+        if (url == null || url.isEmpty()) {
+            Toasty.error(this, "Invalid video URL", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
 
-        customViewContainer = (FrameLayout) findViewById(R.id.customViewContainer);
-        webView = (WebView) findViewById(R.id.webView);
-
+        initializeViews();
+        setupBackupServers();
+        setupWebView();
+        loadUrl(url);
+    }
+    
+    private void initializeViews() {
+        customViewContainer = findViewById(R.id.customViewContainer);
+        webView = findViewById(R.id.webView);
+        
+        // Add progress bar and error text if not in layout
+        progressBar = new ProgressBar(this);
+        errorText = new TextView(this);
+        
+        retryHandler = new Handler();
+    }
+    
+    private void setupBackupServers() {
+        // Generate backup servers based on the original URL
+        backupServers.add(url); // Original server first
+        
+        if (url.contains("vidjoy")) {
+            // VidJoy backup servers with proper URL handling
+            String baseUrl = url.replace("vidjoy.pro", "vidjoy.me")
+                               .replace("vidjoy.me", "vidjoy.me"); // Keep if already vidjoy.me
+            backupServers.add(baseUrl);
+            
+            // Additional VidJoy backups
+            backupServers.add(url.replace("vidjoy.pro", "embedsito.com/v")
+                                .replace("vidjoy.me", "embedsito.com/v"));
+            
+            // Convert to VidSrc as fallback
+            String vidsrcUrl = url.replace("vidjoy.pro/embed", "vidsrc.net/embed")
+                                 .replace("vidjoy.me/embed", "vidsrc.net/embed")
+                                 .replace("embedsito.com/v", "vidsrc.net/embed");
+            backupServers.add(vidsrcUrl);
+            
+            // Add more VidSrc variations
+            backupServers.add(vidsrcUrl.replace("vidsrc.net", "vidsrc.me"));
+            backupServers.add(vidsrcUrl.replace("vidsrc.net", "2embed.to"));
+            
+        } else if (url.contains("vidsrc")) {
+            // VidSrc backup servers
+            backupServers.add(url.replace("vidsrc.net", "vidsrc.me"));
+            backupServers.add(url.replace("vidsrc.net", "2embed.to"));
+            backupServers.add(url.replace("vidsrc.net", "www.2embed.to"));
+            
+            // Convert to VidJoy as backup
+            String vidjoyUrl = url.replace("vidsrc.net/embed", "vidjoy.pro/embed")
+                                 .replace("vidsrc.me/embed", "vidjoy.pro/embed")
+                                 .replace("2embed.to/embed", "vidjoy.pro/embed");
+            backupServers.add(vidjoyUrl);
+        }
+        
+        // Remove duplicates while preserving order
+        List<String> uniqueServers = new ArrayList<>();
+        for (String server : backupServers) {
+            if (!uniqueServers.contains(server)) {
+                uniqueServers.add(server);
+            }
+        }
+        backupServers = uniqueServers;
+        
+        Log.d(TAG, "Setup backup servers: " + backupServers.toString());
+    }
+    
+    private void setupWebView() {
         mWebViewClient = new myWebViewClient();
         webView.setWebViewClient(mWebViewClient);
 
         mWebChromeClient = new myWebChromeClient();
         webView.setWebChromeClient(mWebChromeClient);
+        
+        // Enhanced WebView settings for better compatibility
         webView.getSettings().setJavaScriptEnabled(true);
         webView.getSettings().setAppCacheEnabled(true);
         webView.getSettings().setBuiltInZoomControls(false);
         webView.getSettings().setSaveFormData(true);
-        webView.loadUrl(url);
+        webView.getSettings().setDomStorageEnabled(true);
+        webView.getSettings().setLoadWithOverviewMode(true);
+        webView.getSettings().setUseWideViewPort(true);
+        webView.getSettings().setAllowFileAccess(true);
+        webView.getSettings().setAllowContentAccess(true);
+        webView.getSettings().setMediaPlaybackRequiresUserGesture(false);
+        
+        // Enable video playback
+        webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);
+        webView.getSettings().setSupportMultipleWindows(true);
+        
+        // VidJoy and streaming server specific settings
+        webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
+        webView.getSettings().setAllowFileAccessFromFileURLs(true);
+        webView.getSettings().setLoadsImagesAutomatically(true);
+        webView.getSettings().setBlockNetworkImage(false);
+        webView.getSettings().setBlockNetworkLoads(false);
+        
+        // Set a custom user agent for better server compatibility
+        String userAgent = webView.getSettings().getUserAgentString();
+        webView.getSettings().setUserAgentString(userAgent + " CineMaxPlayer/2.0");
+        
+        // Enable mixed content for HTTPS/HTTP compatibility
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            webView.getSettings().setMixedContentMode(android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+        }
+    }
+    
+    private void loadUrl(String urlToLoad) {
+        Log.d(TAG, "Loading URL: " + urlToLoad);
+        retryCount = 0;
+        webView.loadUrl(urlToLoad);
+    }
+    
+    private void retryWithNextServer() {
+        if (currentServerIndex < backupServers.size() - 1) {
+            currentServerIndex++;
+            String nextServer = backupServers.get(currentServerIndex);
+            Log.d(TAG, "Retrying with backup server: " + nextServer);
+            Toasty.info(this, "Trying backup server...", Toast.LENGTH_SHORT).show();
+            
+            retryHandler.postDelayed(() -> {
+                webView.loadUrl(nextServer);
+                retryCount = 0;
+            }, RETRY_DELAY);
+        } else {
+            // All servers failed
+            Log.e(TAG, "All backup servers failed");
+            Toasty.error(this, "All video servers are unavailable. Please try again later.", Toast.LENGTH_LONG).show();
+            
+            // Show error message to user
+            runOnUiThread(() -> {
+                webView.setVisibility(View.GONE);
+                // Could add an error layout here
+            });
+        }
+    }
+    
+    private void handleLoadError() {
+        retryCount++;
+        Log.w(TAG, "Load error, retry count: " + retryCount);
+        
+        if (retryCount < MAX_RETRIES) {
+            // Retry current server
+            retryHandler.postDelayed(() -> {
+                String currentUrl = backupServers.get(currentServerIndex);
+                Log.d(TAG, "Retrying current server: " + currentUrl);
+                webView.loadUrl(currentUrl);
+            }, RETRY_DELAY);
+        } else {
+            // Try next backup server
+            retryWithNextServer();
+        }
     }
 
     public boolean inCustomView() {
@@ -73,28 +241,38 @@ public class EmbedActivity extends AppCompatActivity {
 
     @Override
     protected void onPause() {
-        super.onPause();    //To change body of overridden methods use File | Settings | File Templates.
+        super.onPause();
         webView.onPause();
     }
 
     @Override
     protected void onResume() {
-        super.onResume();    //To change body of overridden methods use File | Settings | File Templates.
+        super.onResume();
         webView.onResume();
     }
 
     @Override
     protected void onStop() {
-        super.onStop();    //To change body of overridden methods use File | Settings | File Templates.
+        super.onStop();
         if (inCustomView()) {
             hideCustomView();
+        }
+    }
+    
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (retryHandler != null) {
+            retryHandler.removeCallbacksAndMessages(null);
+        }
+        if (webView != null) {
+            webView.destroy();
         }
     }
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK) {
-
             if (inCustomView()) {
                 hideCustomView();
                 return true;
@@ -113,13 +291,26 @@ public class EmbedActivity extends AppCompatActivity {
         private View mVideoProgressView;
 
         @Override
-        public void onShowCustomView(View view, int requestedOrientation, CustomViewCallback callback) {
-            onShowCustomView(view, callback);    //To change body of overridden methods use File | Settings | File Templates.
+        public void onProgressChanged(WebView view, int newProgress) {
+            super.onProgressChanged(view, newProgress);
+            // Update progress bar if available
+            if (progressBar != null) {
+                if (newProgress == 100) {
+                    progressBar.setVisibility(View.GONE);
+                } else {
+                    progressBar.setVisibility(View.VISIBLE);
+                    progressBar.setProgress(newProgress);
+                }
+            }
         }
 
         @Override
-        public void onShowCustomView(View view,CustomViewCallback callback) {
+        public void onShowCustomView(View view, int requestedOrientation, CustomViewCallback callback) {
+            onShowCustomView(view, callback);
+        }
 
+        @Override
+        public void onShowCustomView(View view, CustomViewCallback callback) {
             // if a view already exists then immediately terminate the new one
             if (mCustomView != null) {
                 callback.onCustomViewHidden();
@@ -134,7 +325,6 @@ public class EmbedActivity extends AppCompatActivity {
 
         @Override
         public View getVideoLoadingProgressView() {
-
             if (mVideoProgressView == null) {
                 LayoutInflater inflater = LayoutInflater.from(EmbedActivity.this);
                 mVideoProgressView = inflater.inflate(R.layout.video_progress, null);
@@ -144,7 +334,7 @@ public class EmbedActivity extends AppCompatActivity {
 
         @Override
         public void onHideCustomView() {
-            super.onHideCustomView();    //To change body of overridden methods use File | Settings | File Templates.
+            super.onHideCustomView();
             if (mCustomView == null)
                 return;
 
@@ -165,7 +355,81 @@ public class EmbedActivity extends AppCompatActivity {
     class myWebViewClient extends WebViewClient {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            return super.shouldOverrideUrlLoading(view, url);    //To change body of overridden methods use File | Settings | File Templates.
+            return super.shouldOverrideUrlLoading(view, url);
+        }
+        
+        @Override
+        public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+            super.onReceivedError(view, request, error);
+            Log.e(TAG, "WebView error: " + error.getDescription());
+            
+            // Only handle main frame errors
+            if (request.isForMainFrame()) {
+                handleLoadError();
+            }
+        }
+        
+        @Override
+        public void onPageStarted(WebView view, String url, Bitmap favicon) {
+            super.onPageStarted(view, url, favicon);
+            Log.d(TAG, "Page started loading: " + url);
+        }
+        
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
+            Log.d(TAG, "Page finished loading: " + url);
+            
+            // Special handling for VidJoy servers
+            if (url.contains("vidjoy")) {
+                // Inject JavaScript to detect and handle VidJoy player issues
+                String vidjoyScript = 
+                    "(function() {" +
+                    "  var checkPlayer = function() {" +
+                    "    var video = document.querySelector('video');" +
+                    "    var iframe = document.querySelector('iframe');" +
+                    "    if (video) {" +
+                    "      console.log('Video element found');" +
+                    "      if (video.readyState >= 2) return 'video_ready';" +
+                    "      video.addEventListener('loadeddata', function() { console.log('Video data loaded'); });" +
+                    "      video.addEventListener('error', function() { console.log('Video error'); });" +
+                    "    }" +
+                    "    if (iframe) {" +
+                    "      console.log('Iframe found');" +
+                    "      return 'iframe_found';" +
+                    "    }" +
+                    "    return 'no_player';" +
+                    "  };" +
+                    "  setTimeout(checkPlayer, 2000);" +
+                    "  return checkPlayer();" +
+                    "})();";
+                
+                view.evaluateJavascript(vidjoyScript, result -> {
+                    Log.d(TAG, "VidJoy script result: " + result);
+                    if ("\"no_player\"".equals(result)) {
+                        // No player found, try backup server
+                        retryHandler.postDelayed(() -> handleLoadError(), 5000);
+                    }
+                });
+            }
+            
+            // General check for page content
+            view.evaluateJavascript(
+                "(function() { " +
+                "  var body = document.body;" +
+                "  if (!body || body.innerHTML.length < 100) return 'empty';" +
+                "  var error = document.querySelector('.error, #error, [class*=\"error\"]');" +
+                "  if (error && error.offsetWidth > 0) return 'error_found';" +
+                "  return 'ok';" +
+                "})();",
+                value -> {
+                    Log.d(TAG, "Page content check: " + value);
+                    if ("\"empty\"".equals(value) || "\"error_found\"".equals(value)) {
+                        Log.w(TAG, "Page appears to have issues, treating as error");
+                        retryHandler.postDelayed(() -> handleLoadError(), 3000);
+                    }
+                }
+            );
         }
     }
 }

--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/MovieActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/MovieActivity.java
@@ -359,13 +359,37 @@ public class MovieActivity extends AppCompatActivity {
 
     private void setPlayableList() {
         if (poster != null && poster.getSources() != null) {
+            // Collect all playable sources
+            List<Source> allPlayableSources = new ArrayList<>();
             for (int i = 0; i < poster.getSources().size(); i++) {
                 Source source = poster.getSources().get(i);
                 if (source != null && source.getKind() != null && 
                     (source.getKind().equals("both") || source.getKind().equals("play"))) {
-                    playSources.add(source);
+                    allPlayableSources.add(source);
                 }
             }
+            
+            // Sort sources by priority (primary servers first, then backups)
+            allPlayableSources.sort((s1, s2) -> {
+                int priority1 = s1.getServerPriority();
+                int priority2 = s2.getServerPriority();
+                
+                // If priorities are equal, prefer higher quality
+                if (priority1 == priority2) {
+                    String quality1 = s1.getQuality() != null ? s1.getQuality() : "";
+                    String quality2 = s2.getQuality() != null ? s2.getQuality() : "";
+                    
+                    if (quality1.contains("1080p") && !quality2.contains("1080p")) return -1;
+                    if (!quality1.contains("1080p") && quality2.contains("1080p")) return 1;
+                    if (quality1.contains("720p") && !quality2.contains("720p")) return -1;
+                    if (!quality1.contains("720p") && quality2.contains("720p")) return 1;
+                }
+                
+                return Integer.compare(priority1, priority2);
+            });
+            
+            // Add sorted sources to play list
+            playSources.addAll(allPlayableSources);
         }
     }
     private void setDownloadableList() {

--- a/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/SerieActivity.java
+++ b/CineMax/app/src/main/java/my/cinemax/app/free/ui/activities/SerieActivity.java
@@ -401,13 +401,37 @@ public class SerieActivity extends AppCompatActivity implements PlaylistDownload
         selectedEpisode = episode;
         playableList.clear();
         if (episode != null && episode.getSources() != null) {
+            // Collect all playable sources
+            List<Source> allPlayableSources = new ArrayList<>();
             for (int i = 0; i < episode.getSources().size(); i++) {
                 Source source = episode.getSources().get(i);
                 if (source != null && source.getKind() != null && 
                     (source.getKind().equals("both") || source.getKind().equals("play"))) {
-                    playableList.add(source);
+                    allPlayableSources.add(source);
                 }
             }
+            
+            // Sort sources by priority (primary servers first, then backups)
+            allPlayableSources.sort((s1, s2) -> {
+                int priority1 = s1.getServerPriority();
+                int priority2 = s2.getServerPriority();
+                
+                // If priorities are equal, prefer higher quality
+                if (priority1 == priority2) {
+                    String quality1 = s1.getQuality() != null ? s1.getQuality() : "";
+                    String quality2 = s2.getQuality() != null ? s2.getQuality() : "";
+                    
+                    if (quality1.contains("1080p") && !quality2.contains("1080p")) return -1;
+                    if (!quality1.contains("1080p") && quality2.contains("1080p")) return 1;
+                    if (quality1.contains("720p") && !quality2.contains("720p")) return -1;
+                    if (!quality1.contains("720p") && quality2.contains("720p")) return 1;
+                }
+                
+                return Integer.compare(priority1, priority2);
+            });
+            
+            // Add sorted sources to play list
+            playableList.addAll(allPlayableSources);
         }
 
         if (checkSUBSCRIBED()){

--- a/api_gen.html
+++ b/api_gen.html
@@ -716,6 +716,199 @@
         const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
         const VIDSRC_BASE = 'https://vidsrc.net/embed';
         const VIDJOY_BASE = 'https://vidjoy.pro/embed';
+        
+        // Backup server configurations for better reliability
+        const BACKUP_SERVERS = {
+            vidsrc: {
+                primary: 'https://vidsrc.net/embed',
+                backups: [
+                    'https://vidsrc.me/embed',
+                    'https://2embed.to/embed',
+                    'https://www.2embed.to/embed'
+                ]
+            },
+            vidjoy: {
+                primary: 'https://vidjoy.pro/embed',
+                backups: [
+                    'https://vidjoy.me/embed',
+                    'https://embedsito.com/v',
+                    'https://vidsrc.stream/embed'
+                ]
+            },
+            additional: [
+                {
+                    name: 'SuperEmbed',
+                    base: 'https://multiembed.mov/directstream.php?video_id=',
+                    format: 'movie' // or 'tv'
+                },
+                {
+                    name: 'CloudServe',
+                    base: 'https://embed.su/embed/movie/',
+                    format: 'movie'
+                },
+                {
+                    name: 'EmbedSu',
+                    base: 'https://embed.su/embed/tv/',
+                    format: 'tv'
+                }
+            ]
+        };
+        
+        // Helper function to generate all server variations
+        function generateAllServerSources(tmdbId, type = 'movie', season = null, episode = null) {
+            const sources = [];
+            let idCounter = 1;
+            
+            // Primary VidSrc sources
+            const vidsrcPath = type === 'movie' ? 
+                `/movie/${tmdbId}` : 
+                `/tv/${tmdbId}/${season}/${episode}`;
+                
+            sources.push(
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidSrc Server 1080p",
+                    quality: "1080p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidsrc.primary}${vidsrcPath}`,
+                    serverType: "vidsrc_primary"
+                },
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidSrc Server 720p",
+                    quality: "720p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidsrc.primary}${vidsrcPath}`,
+                    serverType: "vidsrc_primary"
+                }
+            );
+            
+            // VidSrc Backup servers
+            BACKUP_SERVERS.vidsrc.backups.forEach((backupUrl, index) => {
+                sources.push(
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidSrc Backup ${index + 1} 1080p`,
+                        quality: "1080p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidsrcPath}`,
+                        serverType: "vidsrc_backup"
+                    },
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidSrc Backup ${index + 1} 720p`,
+                        quality: "720p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidsrcPath}`,
+                        serverType: "vidsrc_backup"
+                    }
+                );
+            });
+            
+            // Primary VidJoy sources
+            const vidjoyPath = type === 'movie' ? 
+                `/movie/${tmdbId}` : 
+                `/tv/${tmdbId}/${season}/${episode}`;
+                
+            sources.push(
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidJoy Server 1080p",
+                    quality: "1080p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidjoy.primary}${vidjoyPath}`,
+                    serverType: "vidjoy_primary"
+                },
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidJoy Server 720p",
+                    quality: "720p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidjoy.primary}${vidjoyPath}`,
+                    serverType: "vidjoy_primary"
+                }
+            );
+            
+            // VidJoy Backup servers
+            BACKUP_SERVERS.vidjoy.backups.forEach((backupUrl, index) => {
+                sources.push(
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidJoy Backup ${index + 1} 1080p`,
+                        quality: "1080p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidjoyPath}`,
+                        serverType: "vidjoy_backup"
+                    },
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidJoy Backup ${index + 1} 720p`,
+                        quality: "720p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidjoyPath}`,
+                        serverType: "vidjoy_backup"
+                    }
+                );
+            });
+            
+            // Additional backup servers (SuperEmbed, CloudServe, etc.)
+            BACKUP_SERVERS.additional.forEach(server => {
+                if ((type === 'movie' && server.format === 'movie') || 
+                    (type === 'tv' && server.format === 'tv')) {
+                    
+                    const serverPath = type === 'movie' ? 
+                        `${tmdbId}` : 
+                        `${tmdbId}/${season}/${episode}`;
+                        
+                    sources.push({
+                        id: idCounter++,
+                        type: "embed",
+                        title: `${server.name} Server`,
+                        quality: "Auto",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${server.base}${serverPath}`,
+                        serverType: "additional_backup"
+                    });
+                }
+            });
+            
+            return sources;
+        }
 
         // Global data storage
         let currentData = {
@@ -1000,55 +1193,8 @@
                  }
              });
 
-             // Auto-generate VidSrc and VidJoy sources with multiple quality options
-             const autoSources = [
-                 // VidSrc Server - Multiple Quality Options
-                 {
-                     id: nextId++,
-                     type: "embed",
-                     title: "VidSrc Server 1080p",
-                     quality: "1080p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDSRC_BASE}/movie/${tmdbId}`
-                 },
-                 {
-                     id: nextId++,
-                     type: "embed",
-                     title: "VidSrc Server 720p",
-                     quality: "720p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDSRC_BASE}/movie/${tmdbId}`
-                 },
-                 // VidJoy Server - Multiple Quality Options
-                 {
-                     id: nextId++,
-                     type: "embed", 
-                     title: "VidJoy Server 1080p",
-                     quality: "1080p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDJOY_BASE}/movie/${tmdbId}`
-                 },
-                 {
-                     id: nextId++,
-                     type: "embed", 
-                     title: "VidJoy Server 720p",
-                     quality: "720p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDJOY_BASE}/movie/${tmdbId}`
-                 }
-             ];
+                         // Generate all server sources including backups
+            const autoSources = generateAllServerSources(tmdbId, 'movie');
 
              console.log('Auto-generated movie sources:', autoSources);
              console.log('Additional sources:', additionalSources);
@@ -1135,55 +1281,8 @@
                 const episodes = [];
                 
                                  for (const episodeData of seasonData.episodes || []) {
-                     // Auto-generate VidSrc and VidJoy sources with multiple quality options for each episode
-                     const episodeSources = [
-                         // VidSrc Server - Multiple Quality Options
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidSrc Server 1080p",
-                             quality: "1080p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDSRC_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         },
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidSrc Server 720p",
-                             quality: "720p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDSRC_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         },
-                         // VidJoy Server - Multiple Quality Options
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidJoy Server 1080p", 
-                             quality: "1080p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDJOY_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         },
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidJoy Server 720p", 
-                             quality: "720p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDJOY_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         }
-                     ];
+                     // Generate all server sources including backups for each episode
+                     const episodeSources = generateAllServerSources(tmdbId, 'tv', seasonNum, episodeData.episode_number);
 
                      console.log(`Auto-generated sources for S${seasonNum}E${episodeData.episode_number}:`, episodeSources);
 

--- a/index.html
+++ b/index.html
@@ -716,6 +716,199 @@
         const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
         const VIDSRC_BASE = 'https://vidsrc.net/embed';
         const VIDJOY_BASE = 'https://vidjoy.pro/embed';
+        
+        // Backup server configurations for better reliability
+        const BACKUP_SERVERS = {
+            vidsrc: {
+                primary: 'https://vidsrc.net/embed',
+                backups: [
+                    'https://vidsrc.me/embed',
+                    'https://2embed.to/embed',
+                    'https://www.2embed.to/embed'
+                ]
+            },
+            vidjoy: {
+                primary: 'https://vidjoy.pro/embed',
+                backups: [
+                    'https://vidjoy.me/embed',
+                    'https://embedsito.com/v',
+                    'https://vidsrc.stream/embed'
+                ]
+            },
+            additional: [
+                {
+                    name: 'SuperEmbed',
+                    base: 'https://multiembed.mov/directstream.php?video_id=',
+                    format: 'movie' // or 'tv'
+                },
+                {
+                    name: 'CloudServe',
+                    base: 'https://embed.su/embed/movie/',
+                    format: 'movie'
+                },
+                {
+                    name: 'EmbedSu',
+                    base: 'https://embed.su/embed/tv/',
+                    format: 'tv'
+                }
+            ]
+        };
+        
+        // Helper function to generate all server variations
+        function generateAllServerSources(tmdbId, type = 'movie', season = null, episode = null) {
+            const sources = [];
+            let idCounter = 1;
+            
+            // Primary VidSrc sources
+            const vidsrcPath = type === 'movie' ? 
+                `/movie/${tmdbId}` : 
+                `/tv/${tmdbId}/${season}/${episode}`;
+                
+            sources.push(
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidSrc Server 1080p",
+                    quality: "1080p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidsrc.primary}${vidsrcPath}`,
+                    serverType: "vidsrc_primary"
+                },
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidSrc Server 720p",
+                    quality: "720p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidsrc.primary}${vidsrcPath}`,
+                    serverType: "vidsrc_primary"
+                }
+            );
+            
+            // VidSrc Backup servers
+            BACKUP_SERVERS.vidsrc.backups.forEach((backupUrl, index) => {
+                sources.push(
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidSrc Backup ${index + 1} 1080p`,
+                        quality: "1080p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidsrcPath}`,
+                        serverType: "vidsrc_backup"
+                    },
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidSrc Backup ${index + 1} 720p`,
+                        quality: "720p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidsrcPath}`,
+                        serverType: "vidsrc_backup"
+                    }
+                );
+            });
+            
+            // Primary VidJoy sources
+            const vidjoyPath = type === 'movie' ? 
+                `/movie/${tmdbId}` : 
+                `/tv/${tmdbId}/${season}/${episode}`;
+                
+            sources.push(
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidJoy Server 1080p",
+                    quality: "1080p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidjoy.primary}${vidjoyPath}`,
+                    serverType: "vidjoy_primary"
+                },
+                {
+                    id: idCounter++,
+                    type: "embed",
+                    title: "VidJoy Server 720p",
+                    quality: "720p",
+                    size: "Auto",
+                    kind: "play",
+                    premium: "false",
+                    external: false,
+                    url: `${BACKUP_SERVERS.vidjoy.primary}${vidjoyPath}`,
+                    serverType: "vidjoy_primary"
+                }
+            );
+            
+            // VidJoy Backup servers
+            BACKUP_SERVERS.vidjoy.backups.forEach((backupUrl, index) => {
+                sources.push(
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidJoy Backup ${index + 1} 1080p`,
+                        quality: "1080p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidjoyPath}`,
+                        serverType: "vidjoy_backup"
+                    },
+                    {
+                        id: idCounter++,
+                        type: "embed",
+                        title: `VidJoy Backup ${index + 1} 720p`,
+                        quality: "720p",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${backupUrl}${vidjoyPath}`,
+                        serverType: "vidjoy_backup"
+                    }
+                );
+            });
+            
+            // Additional backup servers (SuperEmbed, CloudServe, etc.)
+            BACKUP_SERVERS.additional.forEach(server => {
+                if ((type === 'movie' && server.format === 'movie') || 
+                    (type === 'tv' && server.format === 'tv')) {
+                    
+                    const serverPath = type === 'movie' ? 
+                        `${tmdbId}` : 
+                        `${tmdbId}/${season}/${episode}`;
+                        
+                    sources.push({
+                        id: idCounter++,
+                        type: "embed",
+                        title: `${server.name} Server`,
+                        quality: "Auto",
+                        size: "Auto",
+                        kind: "play",
+                        premium: "false",
+                        external: false,
+                        url: `${server.base}${serverPath}`,
+                        serverType: "additional_backup"
+                    });
+                }
+            });
+            
+            return sources;
+        }
 
         // Global data storage
         let currentData = {
@@ -1000,55 +1193,8 @@
                  }
              });
 
-             // Auto-generate VidSrc and VidJoy sources with multiple quality options
-             const autoSources = [
-                 // VidSrc Server - Multiple Quality Options
-                 {
-                     id: nextId++,
-                     type: "embed",
-                     title: "VidSrc Server 1080p",
-                     quality: "1080p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDSRC_BASE}/movie/${tmdbId}`
-                 },
-                 {
-                     id: nextId++,
-                     type: "embed",
-                     title: "VidSrc Server 720p",
-                     quality: "720p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDSRC_BASE}/movie/${tmdbId}`
-                 },
-                 // VidJoy Server - Multiple Quality Options
-                 {
-                     id: nextId++,
-                     type: "embed", 
-                     title: "VidJoy Server 1080p",
-                     quality: "1080p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDJOY_BASE}/movie/${tmdbId}`
-                 },
-                 {
-                     id: nextId++,
-                     type: "embed", 
-                     title: "VidJoy Server 720p",
-                     quality: "720p",
-                     size: "Auto",
-                     kind: "play",
-                     premium: "false",
-                     external: false,
-                     url: `${VIDJOY_BASE}/movie/${tmdbId}`
-                 }
-             ];
+                         // Generate all server sources including backups
+            const autoSources = generateAllServerSources(tmdbId, 'movie');
 
              console.log('Auto-generated movie sources:', autoSources);
              console.log('Additional sources:', additionalSources);
@@ -1130,56 +1276,9 @@
 
                 const episodes = [];
                 
-                                 for (const episodeData of seasonData.episodes || []) {
-                     // Auto-generate VidSrc and VidJoy sources with multiple quality options for each episode
-                     const episodeSources = [
-                         // VidSrc Server - Multiple Quality Options
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidSrc Server 1080p",
-                             quality: "1080p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDSRC_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         },
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidSrc Server 720p",
-                             quality: "720p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDSRC_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         },
-                         // VidJoy Server - Multiple Quality Options
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidJoy Server 1080p", 
-                             quality: "1080p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDJOY_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         },
-                         {
-                             id: nextId++,
-                             type: "embed",
-                             title: "VidJoy Server 720p", 
-                             quality: "720p",
-                             size: "Auto",
-                             kind: "play",
-                             premium: "false",
-                             external: false,
-                             url: `${VIDJOY_BASE}/tv/${tmdbId}/${seasonNum}/${episodeData.episode_number}`
-                         }
-                     ];
+                                                                  for (const episodeData of seasonData.episodes || []) {
+                     // Generate all server sources including backups for each episode
+                     const episodeSources = generateAllServerSources(tmdbId, 'tv', seasonNum, episodeData.episode_number);
 
                      console.log(`Auto-generated sources for S${seasonNum}E${episodeData.episode_number}:`, episodeSources);
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes VidJoy black screen issue and implements automatic server fallback for improved video playback reliability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous setup caused VidJoy server videos to show a black screen, and required manual selection of backup servers for VidSrc. This PR introduces a robust system to automatically handle server failures and prioritize reliable sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bea903b-5873-47e3-9531-ec845569cbc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bea903b-5873-47e3-9531-ec845569cbc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>