### PR TITLE
Fix embedded link server selector bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,15 +792,12 @@
 .content-card.grid .card-title {
     height: auto; /* Allow title to define its own height up to max-height / line-clamp */
 }
-
-
 .card-meta {
     display: flex;
     gap: 10px;
     font-size: 14px;
     color: var(--youtube-light-gray);
 }
-
 .content-card.grid .card-meta {
     /* display: none; */ /* Hide rating and duration in grid view - Commented out to show meta */
     display: flex; /* Ensure it's a flex container */
@@ -1597,7 +1594,6 @@
             left: 0;
             width: 100%;
         }
-
         /* Loading Spinner */
         .loading-spinner {
             display: none;
@@ -1853,7 +1849,6 @@
                 /* max-height: calc(13px * 1.4 * 2); /* Fallback for non-webkit */
             }
         }
-
         /* Smart TV and Large Screens */
         @media (min-width: 1600px) {
             .carousel {
@@ -2496,6 +2491,7 @@
                                     <button class="action-btn" id="dislike-btn"><i class="fas fa-thumbs-down"></i> <span id="dislike-count-span">1K</span></button>
                                     <button class="action-btn" id="share-video-btn"><i class="fas fa-share"></i> <span>Share</span></button>
                                 </div>
+                                <div id="inline-server-buttons" style="display:flex;flex-wrap:wrap;gap:8px;margin-top:10px;"></div>
                             </div>
                         </div>
 
@@ -2977,7 +2973,6 @@
             return originalWindowOpen.apply(this, arguments);
         };
     </script>
-    
     <script>
         if ('scrollRestoration' in history) {
             history.scrollRestoration = 'manual';
@@ -3723,7 +3718,6 @@
             window.addEventListener('scroll', lazyLoad);
             window.addEventListener('resize', lazyLoad);
         }
-        
         // Open viewer for content
         function openViewer(content) {
             if (playerInstance) {
@@ -3747,7 +3741,7 @@
                 type: content.type,
                 description: content.Description,
                 poster: content.Poster || content.Thumbnail,
-                Servers: content.Servers
+                servers: content.Servers
             };
 
             incrementViewCount(content.Title);
@@ -3779,6 +3773,7 @@
                     console.log('🎬 Loading content with servers:', content.Servers.length, 'servers available');
                     console.log('🔍 Server details:', content.Servers.map(s => ({name: s.name, url: s.url?.substring(0, 50) + '...'})));
                     updatePlayerSource(content.Servers);
+                    renderInlineServerButtons(content.Servers);
                 }
                 elements.seasonsGrid.innerHTML = '';
 
@@ -4525,7 +4520,6 @@
                 return { hasDRM: false };
             }
         }
-        
         // Universal channel format detection and handling
         function detectChannelFormat(url) {
             const formatInfo = {
@@ -5324,7 +5318,6 @@
                    url.includes('godriveplayer') || url.includes('vidlink.pro') || url.includes('2embed.cc') ||
                    url.includes('embed.su') || url.includes('autoembed.cc');
         }
-
         // Check if URL is Vidjoy
         function isVidjoyUrl(url) {
             if (!url) return false;
@@ -5919,7 +5912,6 @@
             if (!url) return false;
             return url.includes('drive.google.com') || url.includes('drive.usercontent.google.com');
         }
-
         // Direct Link Server Selector Functions
         function showDirectLinkServerSelector() {
             if (!currentContentInfo || !currentContentInfo.servers || currentContentInfo.servers.length <= 1) {
@@ -6523,7 +6515,6 @@
             // If episode navigation fails, close viewer
             closeViewerInternalLogic();
         }
-
         // Setup event listeners
         function setupEventListeners() {
             // Theme toggle
@@ -6835,8 +6826,6 @@
     timeout = setTimeout(later, wait);
   };
 }
-
-
         // Handle search
         function handleSearch() {
             const query = elements.searchInput.value.toLowerCase();

--- a/index.html
+++ b/index.html
@@ -3042,7 +3042,8 @@
             nextEpisodeBtn: null,
             hamburgerBtn: document.getElementById('hamburger-btn'),
             mobileFiltersMenu: document.querySelector('.mobile-filters-menu'),
-            stretchBtn: document.getElementById('stretch-btn')
+            stretchBtn: document.getElementById('stretch-btn'),
+            inlineServerButtons: document.getElementById('inline-server-buttons')
         };
         
         // State
@@ -4497,7 +4498,6 @@
             
             updateLoadingStatus('All MPD sources failed. Please try again later.', true);
         }
-        
         // Detect DRM protection in MPD manifest
         async function detectDRMProtection(mpdUrl) {
             try {
@@ -5248,7 +5248,6 @@
                 }
             }
         }
-
         // Universal DRM detection for any channel
         async function detectChannelDRMRequirements(url, servers = []) {
             try {
@@ -6325,6 +6324,7 @@
                 console.log('📺 Playing episode with servers:', episode.Servers.length, 'servers available');
                 console.log('🔍 Episode server details:', episode.Servers.map(s => ({name: s.name, url: s.url?.substring(0, 50) + '...'})));
                 updatePlayerSource(episode.Servers);
+                renderInlineServerButtons(episode.Servers);
             }
 
             // Ensure the episode selector reflects the current episode

--- a/index.html
+++ b/index.html
@@ -3963,8 +3963,8 @@
             if (isVidsrcUrl(url) || isVidjoyUrl(url) || isVidsrcMeUrl(url) || isVidsrcToUrl(url) || isVidsrcXyzUrl(url) || isGoDrivePlayerUrl(url) || isVidLinkProUrl(url) || is2EmbedUrl(url) || isEmbedSuUrl(url) || isAutoEmbedUrl(url)) {
                 elements.player.style.display = 'none'; // Hide Plyr player
                 
-                // Create server selector for embedded sources (non-blocking)
-                setTimeout(() => createEmbeddedServerSelector(servers), 100);
+                // Create server selector for all sources (non-blocking)
+                setTimeout(() => createAllServersSelector(servers), 100);
                 
                 if (!iframe) {
                     iframe = createSecureIframe(url, playerContainer);
@@ -4133,8 +4133,8 @@
                     iframe.src = 'about:blank'; // Clear the iframe src
                 }
                 
-                // Hide embedded server selector when switching to non-embedded sources
-                hideEmbeddedServerSelector();
+                // Hide all servers selector when switching to non-embedded sources
+                hideAllServersSelector();
                 
                 elements.player.style.display = 'block'; // Show Plyr player
             }
@@ -5380,7 +5380,7 @@
         }
 
         // Create server selector for ALL sources (embedded and direct links)
-        function createEmbeddedServerSelector(servers) {
+        function createAllServersSelector(servers) {
             if (!servers || servers.length <= 1) {
                 console.log('🔍 Server selector not created - only', servers?.length || 0, 'servers available');
                 return; // No need for selector if only one server
@@ -5389,14 +5389,14 @@
             console.log('🎯 Creating server selector with', servers.length, 'servers:', servers.map(s => s.name || 'Unknown'));
             
             // Remove existing server selector if it exists
-            const existingSelector = document.getElementById('embedded-server-selector');
+            const existingSelector = document.getElementById('all-servers-selector');
             if (existingSelector) {
                 existingSelector.remove();
             }
             
             // Create server selector container
             const selectorContainer = document.createElement('div');
-            selectorContainer.id = 'embedded-server-selector';
+            selectorContainer.id = 'all-servers-selector';
             selectorContainer.style.cssText = `
                 position: absolute;
                 top: 10px;
@@ -5424,7 +5424,7 @@
                 margin-bottom: 8px;
                 text-align: center;
             `;
-            title.textContent = '🌐 Server Selection';
+            title.textContent = '🌐 All Server Sources';
             selectorContainer.appendChild(title);
             
             // Add Back to Home button
@@ -5637,11 +5637,56 @@
                             // Show loading indicator for server switch
                             showLoadingIndicator(`Switching to ${displayName}...`);
                             
-                            iframe.src = filterEmbeddedUrl(server.url);
+                            // Check if this is a direct video link or embedded link
+                            const isDirectVideo = server.url.includes('.m3u8') || server.url.includes('.mpd') || 
+                                               server.url.includes('.mp4') || server.url.includes('.mkv') || 
+                                               server.url.includes('.avi') || server.url.includes('.mov') || 
+                                               server.url.includes('.webm') || server.url.includes('.flv');
+                            
+                            if (isDirectVideo) {
+                                // For direct video links, switch back to Plyr player
+                                iframe.style.display = 'none';
+                                iframe.src = 'about:blank';
+                                
+                                // Show the Plyr player again
+                                if (elements.player) {
+                                    elements.player.style.display = 'block';
+                                }
+                                
+                                // Update Plyr source with the selected server
+                                if (playerInstance) {
+                                    const sources = [{
+                                        src: server.url,
+                                        size: parseInt(server.name?.replace(/\D/g, '') || '0'),
+                                        type: server.url.includes('m3u8') ? 'application/x-mpegURL' : 
+                                              server.url.includes('mpd') ? 'application/dash+xml' : 'video/mp4'
+                                    }];
+                                    
+                                    playerInstance.source = {
+                                        type: 'video',
+                                        sources: sources,
+                                    };
+                                    
+                                    // Play the video
+                                    playerInstance.play();
+                                }
+                                
+                                // Remove the server selector
+                                selectorContainer.remove();
+                                
+                                // Remove the indicator button
+                                const indicatorButton = document.getElementById('server-selector-indicator');
+                                if (indicatorButton) {
+                                    indicatorButton.remove();
+                                }
+                            } else {
+                                // For embedded links, update iframe source
+                                iframe.src = filterEmbeddedUrl(server.url);
+                            }
                             
                             // Auto-hide server selector after selection
                             setTimeout(() => {
-                                const selector = document.getElementById('embedded-server-selector');
+                                const selector = document.getElementById('all-servers-selector');
                                 if (selector) {
                                     selector.style.opacity = '0.3';
                                     selector.style.transform = 'scale(0.95)';
@@ -5650,7 +5695,7 @@
                         }
                         
                         // Update visual selection
-                        document.querySelectorAll('#embedded-server-selector .server-item').forEach(item => {
+                        document.querySelectorAll('#all-servers-selector .server-item').forEach(item => {
                             item.style.background = 'rgba(255, 255, 255, 0.1)';
                             item.style.border = 'none';
                         });
@@ -5723,7 +5768,7 @@
                     opacity: 0.7;
                 `;
                 indicatorButton.innerHTML = `🌐 ${servers.length} Server${servers.length !== 1 ? 's' : ''}`;
-                indicatorButton.title = `Click to show server selector - ${servers.length} embedded sources available (Ctrl+S)`;
+                indicatorButton.title = `Click to show server selector - ${servers.length} total sources available (Ctrl+S)`;
                 
                 indicatorButton.addEventListener('click', () => {
                     selectorContainer.style.opacity = '1';
@@ -5801,9 +5846,9 @@
             selectorContainer._keyPressHandler = handleKeyPress;
         }
 
-        // Hide embedded server selector
-        function hideEmbeddedServerSelector() {
-            const existingSelector = document.getElementById('embedded-server-selector');
+        // Hide all servers selector
+        function hideAllServersSelector() {
+            const existingSelector = document.getElementById('all-servers-selector');
             if (existingSelector) {
                 // Remove keyboard event listener before removing element
                 if (existingSelector._keyPressHandler) {
@@ -5818,7 +5863,7 @@
                 indicatorButton.remove();
             }
             
-            // Clear any loading messages for embedded content
+            // Clear any loading messages for server content
             if (elements.playerMessageArea && elements.playerMessageArea.textContent.includes('embedded')) {
                 elements.playerMessageArea.style.display = 'none';
             }
@@ -6751,7 +6796,7 @@
                     const playerContainer = document.querySelector('.player-container');
                     const iframe = playerContainer && playerContainer.querySelector('iframe.external-content-iframe');
                     if (iframe && iframe.style.display !== 'none') {
-                        createEmbeddedServerSelector(servers);
+                        createAllServersSelector(servers);
                     } else {
                         showDirectLinkServerSelector();
                     }
@@ -6920,7 +6965,7 @@
                     {name: 'Google Drive', url: 'https://drive.google.com/file/d/123'},
                 ];
                 console.log('📊 Test servers:', testServers);
-                createEmbeddedServerSelector(testServers);
+                createAllServersSelector(testServers);
             };
         });
 

--- a/index.html
+++ b/index.html
@@ -5379,7 +5379,7 @@
             return url.includes('autoembed.cc');
         }
 
-        // Create server selector for embedded sources when Plyr player is hidden
+        // Create server selector for ALL sources (embedded and direct links)
         function createEmbeddedServerSelector(servers) {
             if (!servers || servers.length <= 1) {
                 console.log('🔍 Server selector not created - only', servers?.length || 0, 'servers available');
@@ -5486,7 +5486,7 @@
             });
             selectorContainer.appendChild(backToHomeButton);
             
-            // Group servers by type for better organization
+            // Group servers by type for better organization - now including ALL server types
             const serverGroups = {};
             console.log('🔍 Processing servers for grouping:', servers.length, 'total servers');
             
@@ -5501,6 +5501,14 @@
                 else if (isVidLinkProUrl(server.url)) group = 'VidLink.pro';
                 else if (isGoogleDriveUrl(server.url)) group = 'Google Drive';
                 else if (isMegaNzUrl(server.url)) group = 'Mega.nz';
+                else if (server.url.includes('.m3u8')) group = 'HLS Streams';
+                else if (server.url.includes('.mpd')) group = 'MPD Streams';
+                else if (server.url.includes('.mp4')) group = 'MP4 Files';
+                else if (server.url.includes('.mkv')) group = 'MKV Files';
+                else if (server.url.includes('.avi')) group = 'AVI Files';
+                else if (server.url.includes('.mov')) group = 'MOV Files';
+                else if (server.url.includes('.webm')) group = 'WebM Files';
+                else if (server.url.includes('.flv')) group = 'FLV Files';
                 
                 if (!serverGroups[group]) serverGroups[group] = [];
                 serverGroups[group].push(server);


### PR DESCRIPTION
Unify the server selector to display all available embedded and direct video sources in a single interface, fixing the issue where only a subset of servers was visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-71520d72-7940-41ee-a9b5-e76831d9e0a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71520d72-7940-41ee-a9b5-e76831d9e0a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

