### PR TITLE
Fix live tv image display for uniformity

### DIFF
--- a/index.html
+++ b/index.html
@@ -832,6 +832,20 @@
         }
 
 
+        /* Live TV: uniform, non-cropped logos */
+        .content-card[data-type="live"] .card-img {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: var(--youtube-dark-gray);
+        }
+        .content-card[data-type="live"] .card-img img {
+            object-fit: contain;
+            width: 100%;
+            height: 100%;
+            padding: 8%;
+        }
+
         /* Viewer Page - YouTube Style */
         .viewer-page {
             display: none;


### PR DESCRIPTION
Standardize Live TV thumbnail images to be uniformly sized and prevent cropping.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd4ad4af-a4f6-4ab0-9a94-3f4a971a8c3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd4ad4af-a4f6-4ab0-9a94-3f4a971a8c3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

