### PR TITLE
Add another video frame to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5034,8 +5034,8 @@
         // Check if URL is Vidsrc
         function isVidsrcUrl(url) {
             if (!url) return false;
-            return url.includes('vidsrc.net/embed') || url.includes('vidsrc.me/embed') || url.includes('vidsrc.pro/embed') || 
-                   url.includes('vidsrc.me') || url.includes('vidsrc.to') || url.includes('vidsrc.xyz') ||
+            return url.includes('vidsrc.net/embed') || url.includes('vidsrc.me/embed') || url.includes('vidsrc.pro/embed') || url.includes('vidsrc.win/embed') || 
+                   url.includes('vidsrc.me') || url.includes('vidsrc.to') || url.includes('vidsrc.xyz') || url.includes('vidsrc.win') ||
                    url.includes('godriveplayer') || url.includes('vidlink.pro') || url.includes('2embed.cc') ||
                    url.includes('embed.su') || url.includes('autoembed.cc') || url.includes('vidfast.pro');
         }

--- a/index.html
+++ b/index.html
@@ -5037,7 +5037,7 @@
             return url.includes('vidsrc.net/embed') || url.includes('vidsrc.me/embed') || url.includes('vidsrc.pro/embed') || 
                    url.includes('vidsrc.me') || url.includes('vidsrc.to') || url.includes('vidsrc.xyz') ||
                    url.includes('godriveplayer') || url.includes('vidlink.pro') || url.includes('2embed.cc') ||
-                   url.includes('embed.su') || url.includes('autoembed.cc');
+                   url.includes('embed.su') || url.includes('autoembed.cc') || url.includes('vidfast.pro');
         }
 
         // Check if URL is Vidjoy


### PR DESCRIPTION
Add `vidfast.pro` to the list of recognized embedded video sources.

This allows `vidfast.pro` URLs to be embedded and handled like other existing video providers (vidsrc, vidjoy, vidlink).

---
<a href="https://cursor.com/background-agent?bcId=bc-1296fe50-4741-4034-b9a8-60ec26db7190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1296fe50-4741-4034-b9a8-60ec26db7190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

